### PR TITLE
feat: add UI widget framework

### DIFF
--- a/Solo/UI/Tooltips/TooltipContent.cs
+++ b/Solo/UI/Tooltips/TooltipContent.cs
@@ -1,0 +1,69 @@
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+
+namespace Solo.UI.Tooltips;
+
+public record TooltipLine(string Text, Color Color);
+
+public class TooltipContent
+{
+    private readonly List<TooltipLine> _lines = new();
+
+    public IReadOnlyList<TooltipLine> Lines => _lines;
+
+    public TooltipContent AddLine(string text, Color color)
+    {
+        _lines.Add(new TooltipLine(text, color));
+        return this;
+    }
+
+    public TooltipContent AddLine(string text)
+    {
+        _lines.Add(new TooltipLine(text, UITheme.Text.Primary));
+        return this;
+    }
+
+    public TooltipContent AddEmptyLine()
+    {
+        _lines.Add(new TooltipLine("", UITheme.Text.Primary));
+        return this;
+    }
+
+    public static TooltipContent FromPlainText(string text)
+    {
+        var content = new TooltipContent();
+        var lines = text.Split('\n');
+        foreach (var line in lines)
+        {
+            content.AddLine(line.TrimEnd('\r'));
+        }
+        return content;
+    }
+}
+
+public record TooltipColumnHeader(string ItemName, string? SlotLabel);
+
+public record TooltipTableCell(string Value, Color Color);
+
+public record TooltipTableRow(string StatName, IReadOnlyList<TooltipTableCell> Cells);
+
+public class TooltipTableData
+{
+    private readonly List<TooltipColumnHeader> _headers = new();
+    private readonly List<TooltipTableRow> _rows = new();
+
+    public IReadOnlyList<TooltipColumnHeader> Headers => _headers;
+    public IReadOnlyList<TooltipTableRow> Rows => _rows;
+
+    public TooltipTableData AddHeader(string itemName, string? slotLabel = null)
+    {
+        _headers.Add(new TooltipColumnHeader(itemName, slotLabel));
+        return this;
+    }
+
+    public TooltipTableData AddRow(string statName, IReadOnlyList<TooltipTableCell> cells)
+    {
+        _rows.Add(new TooltipTableRow(statName, cells));
+        return this;
+    }
+}

--- a/Solo/UI/UIResources.cs
+++ b/Solo/UI/UIResources.cs
@@ -1,0 +1,18 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Solo.Utils;
+
+namespace Solo.UI;
+
+public static class UIResources
+{
+    private static Texture2D? _pixelTexture;
+
+    public static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null || _pixelTexture.IsDisposed)
+            _pixelTexture = graphicsDevice.Generate(1, 1, Color.White);
+
+        return _pixelTexture;
+    }
+}

--- a/Solo/UI/UIService.cs
+++ b/Solo/UI/UIService.cs
@@ -1,0 +1,260 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using Solo.Services;
+using Solo.UI.Tooltips;
+using Solo.UI.Widgets;
+
+namespace Solo.UI;
+
+public class UIService : IGameService, IRenderable
+{
+    private readonly List<Widget> _rootWidgets = new();
+    private MouseState _previousMouseState;
+    private TooltipWidget? _tooltip;
+    private int _lastViewportHeight;
+
+    public int LayerIndex { get; set; } = int.MaxValue - 1000;
+    public bool Hidden { get; set; } = false;
+
+    public void Initialize()
+    {
+        _previousMouseState = Mouse.GetState();
+        _tooltip = new TooltipWidget();
+
+        var viewport = GraphicsDeviceManagerAccessor.Instance.GraphicsDeviceManager.GraphicsDevice.Viewport;
+        _lastViewportHeight = viewport.Height;
+        UITheme.UpdateUIScale(viewport.Height);
+    }
+
+    public void AddWidget(Widget widget)
+    {
+        if (!_rootWidgets.Contains(widget))
+            _rootWidgets.Add(widget);
+    }
+
+    public void RemoveWidget(Widget widget)
+    {
+        _rootWidgets.Remove(widget);
+    }
+
+    public void ClearWidgets()
+    {
+        _rootWidgets.Clear();
+    }
+
+    public void Update(GameTime gameTime)
+    {
+        var viewport = GraphicsDeviceManagerAccessor.Instance.GraphicsDeviceManager.GraphicsDevice.Viewport;
+        if (viewport.Height != _lastViewportHeight)
+        {
+            _lastViewportHeight = viewport.Height;
+            UITheme.UpdateUIScale(viewport.Height);
+        }
+
+        var rawMouseState = Mouse.GetState();
+        var mouseState = ScaleMouseState(rawMouseState);
+        var previousMouseState = _previousMouseState;
+
+        if (rawMouseState.LeftButton == ButtonState.Released &&
+            _previousMouseState.LeftButton == ButtonState.Pressed)
+        {
+            var mousePoint = new Point(mouseState.X, mouseState.Y);
+            for (int i = _rootWidgets.Count - 1; i >= 0; i--)
+            {
+                if (_rootWidgets[i].HandleMouseClick(mousePoint))
+                    break;
+            }
+        }
+
+        foreach (var widget in _rootWidgets)
+        {
+            widget.Update(gameTime, mouseState, previousMouseState);
+        }
+
+        UpdateTooltip(mouseState);
+
+        _previousMouseState = mouseState;
+    }
+
+    private static MouseState ScaleMouseState(MouseState mouseState)
+    {
+        float scale = UITheme.UIScale;
+        if (scale >= 1f)
+            return mouseState;
+
+        return new MouseState(
+            (int)(mouseState.X / scale),
+            (int)(mouseState.Y / scale),
+            mouseState.ScrollWheelValue,
+            mouseState.LeftButton,
+            mouseState.MiddleButton,
+            mouseState.RightButton,
+            mouseState.XButton1,
+            mouseState.XButton2
+        );
+    }
+
+    private void UpdateTooltip(MouseState mouseState)
+    {
+        if (_tooltip == null)
+            return;
+
+        var mousePoint = new Point(mouseState.X, mouseState.Y);
+
+        TooltipTableData? tableData = null;
+        TooltipContent? tooltipContent = null;
+        string? tooltipText = null;
+
+        for (int i = _rootWidgets.Count - 1; i >= 0; i--)
+        {
+            var root = _rootWidgets[i];
+            if (root.Visible)
+            {
+                tableData = FindTooltipTableData(root, mousePoint);
+                if (tableData != null)
+                    break;
+
+                tooltipContent = FindTooltipContent(root, mousePoint);
+                if (tooltipContent != null)
+                    break;
+
+                tooltipText = FindTooltipText(root, mousePoint);
+                if (tooltipText != null)
+                    break;
+            }
+        }
+
+        if (tableData != null)
+        {
+            _tooltip.SetTableContent(tableData);
+            PositionTooltip(mouseState);
+            _tooltip.Visible = true;
+        }
+        else if (tooltipContent != null)
+        {
+            _tooltip.SetContent(tooltipContent);
+            PositionTooltip(mouseState);
+            _tooltip.Visible = true;
+        }
+        else if (tooltipText != null)
+        {
+            _tooltip.SetText(tooltipText);
+            PositionTooltip(mouseState);
+            _tooltip.Visible = true;
+        }
+        else
+        {
+            _tooltip.Visible = false;
+        }
+    }
+
+    private void PositionTooltip(MouseState mouseState)
+    {
+        if (_tooltip == null)
+            return;
+
+        var tooltipX = mouseState.X + 16;
+        var tooltipY = mouseState.Y + 16;
+
+        var viewport = GraphicsDeviceManagerAccessor.Instance.GraphicsDeviceManager.GraphicsDevice.Viewport;
+        var screenWidth = (int)(viewport.Width / UITheme.UIScale);
+        var screenHeight = (int)(viewport.Height / UITheme.UIScale);
+
+        if (tooltipX + _tooltip.Size.X > screenWidth)
+            tooltipX = mouseState.X - (int)_tooltip.Size.X - 8;
+        if (tooltipY + _tooltip.Size.Y > screenHeight)
+            tooltipY = mouseState.Y - (int)_tooltip.Size.Y - 8;
+
+        _tooltip.Position = new Vector2(tooltipX, tooltipY);
+    }
+
+    private static TooltipTableData? FindTooltipTableData(Widget widget, Point mousePoint)
+    {
+        if (!widget.Visible)
+            return null;
+
+        for (int i = widget.Children.Count - 1; i >= 0; i--)
+        {
+            var result = FindTooltipTableData(widget.Children[i], mousePoint);
+            if (result != null)
+                return result;
+        }
+
+        if (widget.Bounds.Contains(mousePoint))
+        {
+            return widget.GetTooltipTableData();
+        }
+
+        return null;
+    }
+
+    private static TooltipContent? FindTooltipContent(Widget widget, Point mousePoint)
+    {
+        if (!widget.Visible)
+            return null;
+
+        for (int i = widget.Children.Count - 1; i >= 0; i--)
+        {
+            var result = FindTooltipContent(widget.Children[i], mousePoint);
+            if (result != null)
+                return result;
+        }
+
+        if (widget.Bounds.Contains(mousePoint))
+        {
+            return widget.GetTooltipContent();
+        }
+
+        return null;
+    }
+
+    private static string? FindTooltipText(Widget widget, Point mousePoint)
+    {
+        if (!widget.Visible)
+            return null;
+
+        for (int i = widget.Children.Count - 1; i >= 0; i--)
+        {
+            var result = FindTooltipText(widget.Children[i], mousePoint);
+            if (result != null)
+                return result;
+        }
+
+        if (widget.Bounds.Contains(mousePoint))
+        {
+            return widget.GetTooltipText();
+        }
+
+        return null;
+    }
+
+    public bool HasVisibleWidgets()
+    {
+        foreach (var widget in _rootWidgets)
+        {
+            if (widget.Visible)
+                return true;
+        }
+        return false;
+    }
+
+    public void Render(SpriteBatch spriteBatch)
+    {
+        var sampler = UITheme.UIScale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
+        var matrix = UITheme.UIScale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
+
+        spriteBatch.End();
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, sampler, null, null, null, matrix);
+
+        foreach (var widget in _rootWidgets)
+        {
+            widget.Render(spriteBatch);
+        }
+
+        _tooltip?.Render(spriteBatch);
+
+        spriteBatch.End();
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.PointClamp);
+    }
+}

--- a/Solo/UI/UITheme.cs
+++ b/Solo/UI/UITheme.cs
@@ -1,0 +1,397 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using System.Text.Json;
+
+namespace Solo.UI;
+
+public static class UITheme
+{
+    private const float ReferenceHeight = 1080f;
+
+    private static UIThemeData _theme = new();
+    private static float _uiScale = 1f;
+    private static Matrix _uiScaleMatrix = Matrix.Identity;
+    private static Dictionary<string, Color> _customColors = new();
+    private static Dictionary<string, float> _customFloats = new();
+
+    public static float UIScale => _uiScale;
+    public static Matrix UIScaleMatrix => _uiScaleMatrix;
+
+    public static void UpdateUIScale(int viewportHeight)
+    {
+        _uiScale = Math.Min(1f, viewportHeight / ReferenceHeight);
+        _uiScaleMatrix = Matrix.CreateScale(_uiScale, _uiScale, 1f);
+    }
+
+    public static SpriteFont Font => _theme.Fonts.Default;
+    public static SpriteFont TooltipFont => _theme.Fonts.Tooltip;
+    public static SpriteFont TitleFont => _theme.Fonts.Title;
+
+    public static int LineHeight => Font.LineSpacing;
+    public static int MenuItemHeight => LineHeight + 16;
+    public static int BreadcrumbHeight => (int)(Font.LineSpacing * 1.3f) + 8 + 1;
+    public static int LabelRowHeight => LineHeight + 8;
+    public static int ButtonRowHeight => LineHeight + 24;
+    public static int SectionSpacing => Math.Max(8, LineHeight / 2);
+
+    public static PanelStyle Panel => _theme.Panel;
+    public static ButtonStyle Button => _theme.Button;
+    public static PanelStyle Input => _theme.Input;
+    public static PanelStyle Tooltip => _theme.Tooltip;
+    public static TextColors Text => _theme.Text;
+    public static SelectionColors Selection => _theme.Selection;
+    public static StatusBarColors StatusBar => _theme.StatusBar;
+    public static ScrollbarColors Scrollbar => _theme.Scrollbar;
+
+    public static Color GetColor(string key, Color? defaultValue = null)
+    {
+        if (_customColors.TryGetValue(key, out var color))
+            return color;
+        return defaultValue ?? Color.White;
+    }
+
+    public static float GetFloat(string key, float defaultValue = 0f)
+    {
+        if (_customFloats.TryGetValue(key, out var value))
+            return value;
+        return defaultValue;
+    }
+
+    private const string DefaultFontAsset = "Font";
+
+    public static void Load(string path, ContentManager content)
+    {
+        UIThemeJson? data = null;
+
+        if (File.Exists(path))
+        {
+            var json = File.ReadAllText(path);
+            data = JsonSerializer.Deserialize<UIThemeJson>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+        else
+        {
+            Console.WriteLine($"UITheme: Config file not found at {path}, using defaults");
+        }
+
+        var fonts = LoadFonts(content, data?.Fonts);
+
+        if (data != null)
+        {
+            _theme = new UIThemeData
+            {
+                Fonts = fonts,
+                Panel = ParsePanelStyle(data.Panel),
+                Button = ParseButtonStyle(data.Button),
+                Input = ParsePanelStyle(data.Input),
+                Tooltip = ParsePanelStyle(data.Tooltip),
+                Text = ParseTextColors(data.Text),
+                Selection = ParseSelectionColors(data.Selection),
+                StatusBar = ParseStatusBarColors(data.StatusBar),
+                Scrollbar = ParseScrollbarColors(data.Scrollbar)
+            };
+
+            ParseCustomSection(data.Custom);
+        }
+        else
+        {
+            _theme = new UIThemeData { Fonts = fonts };
+        }
+    }
+
+    private static ThemeFonts LoadFonts(ContentManager content, FontsJson? fonts)
+    {
+        var defaultAsset = fonts?.Default ?? DefaultFontAsset;
+        return new ThemeFonts
+        {
+            Default = content.Load<SpriteFont>(defaultAsset),
+            Tooltip = content.Load<SpriteFont>(fonts?.Tooltip ?? defaultAsset),
+            Title = content.Load<SpriteFont>(fonts?.Title ?? defaultAsset)
+        };
+    }
+
+    private static PanelStyle ParsePanelStyle(PanelStyleJson? json)
+    {
+        if (json == null)
+            return new PanelStyle();
+
+        return new PanelStyle
+        {
+            BackgroundColor = ParseColor(json.BackgroundColor) ?? new Color(40, 40, 40, 220),
+            BorderColor = ParseColor(json.BorderColor) ?? new Color(80, 80, 80),
+            BorderWidth = json.BorderWidth ?? 2,
+            ContentPadding = json.ContentPadding ?? 16
+        };
+    }
+
+    private static ButtonStyle ParseButtonStyle(ButtonStyleJson? json)
+    {
+        if (json == null)
+            return new ButtonStyle();
+
+        return new ButtonStyle
+        {
+            BackgroundColor = ParseColor(json.BackgroundColor) ?? new Color(60, 60, 60, 230),
+            BorderColor = ParseColor(json.BorderColor) ?? new Color(100, 100, 100),
+            BorderWidth = json.BorderWidth ?? 2,
+            ContentPadding = json.ContentPadding ?? 0,
+            HoverBackgroundColor = ParseColor(json.HoverBackgroundColor) ?? new Color(80, 75, 65, 240),
+            HoverBorderColor = ParseColor(json.HoverBorderColor) ?? new Color(200, 180, 140),
+            DisabledBackgroundColor = ParseColor(json.DisabledBackgroundColor) ?? new Color(35, 35, 35, 200),
+            DisabledBorderColor = ParseColor(json.DisabledBorderColor) ?? new Color(50, 50, 50)
+        };
+    }
+
+    private static TextColors ParseTextColors(TextColorsJson? json)
+    {
+        if (json == null)
+            return new TextColors();
+
+        return new TextColors
+        {
+            Primary = ParseColor(json.Primary) ?? Color.White,
+            Secondary = ParseColor(json.Secondary) ?? Color.LightGray,
+            Muted = ParseColor(json.Muted) ?? Color.Gray,
+            Error = ParseColor(json.Error) ?? Color.Red,
+            Warning = ParseColor(json.Warning) ?? Color.Yellow,
+            Title = ParseColor(json.Title) ?? new Color(220, 200, 160),
+            Highlight = ParseColor(json.Highlight) ?? new Color(200, 180, 140),
+            Subtitle = ParseColor(json.Subtitle) ?? new Color(160, 160, 160),
+            SectionHeader = ParseColor(json.SectionHeader) ?? new Color(150, 150, 150),
+            Placeholder = ParseColor(json.Placeholder) ?? new Color(100, 100, 100),
+            Shadow = ParseColor(json.Shadow) ?? Color.Black
+        };
+    }
+
+    private static SelectionColors ParseSelectionColors(SelectionColorsJson? json)
+    {
+        if (json == null)
+            return new SelectionColors();
+
+        return new SelectionColors
+        {
+            SelectedBackground = ParseColor(json.SelectedBackground) ?? new Color(80, 70, 50),
+            HoverBackground = ParseColor(json.HoverBackground) ?? new Color(60, 60, 60),
+            SelectionBorder = ParseColor(json.SelectionBorder) ?? new Color(200, 180, 140),
+            HoverBorder = ParseColor(json.HoverBorder) ?? new Color(150, 150, 150, 180),
+            InvalidDrop = ParseColor(json.InvalidDrop) ?? new Color(200, 50, 50, 180),
+            ValidDrop = ParseColor(json.ValidDrop) ?? new Color(50, 200, 50, 180),
+            EmptySlot = ParseColor(json.EmptySlot) ?? new Color(50, 50, 50, 150),
+            SlotHover = ParseColor(json.SlotHover) ?? new Color(60, 60, 80, 220),
+            CloseButton = ParseColor(json.CloseButton) ?? new Color(180, 60, 60)
+        };
+    }
+
+    private static StatusBarColors ParseStatusBarColors(StatusBarColorsJson? json)
+    {
+        if (json == null)
+            return new StatusBarColors();
+
+        return new StatusBarColors
+        {
+            ProgressFill = ParseColor(json.ProgressFill) ?? new Color(80, 200, 80),
+            ProgressBackground = ParseColor(json.ProgressBackground) ?? new Color(40, 40, 40)
+        };
+    }
+
+    private static ScrollbarColors ParseScrollbarColors(ScrollbarColorsJson? json)
+    {
+        if (json == null)
+            return new ScrollbarColors();
+
+        return new ScrollbarColors
+        {
+            Track = ParseColor(json.Track) ?? new Color(40, 40, 40, 150),
+            Thumb = ParseColor(json.Thumb) ?? new Color(120, 120, 120, 200)
+        };
+    }
+
+    private static void ParseCustomSection(Dictionary<string, Dictionary<string, int[]>>? custom)
+    {
+        _customColors.Clear();
+        _customFloats.Clear();
+
+        if (custom == null)
+            return;
+
+        foreach (var section in custom)
+        {
+            foreach (var entry in section.Value)
+            {
+                var key = $"{section.Key}.{entry.Key}";
+                var color = ParseColor(entry.Value);
+                if (color.HasValue)
+                    _customColors[key] = color.Value;
+            }
+        }
+    }
+
+    private static Color? ParseColor(int[]? rgba)
+    {
+        if (rgba == null || rgba.Length < 3)
+            return null;
+
+        int r = rgba[0];
+        int g = rgba[1];
+        int b = rgba[2];
+        int a = rgba.Length >= 4 ? rgba[3] : 255;
+
+        return new Color(r, g, b, a);
+    }
+
+    private class UIThemeJson
+    {
+        public FontsJson? Fonts { get; set; }
+        public PanelStyleJson? Panel { get; set; }
+        public ButtonStyleJson? Button { get; set; }
+        public PanelStyleJson? Input { get; set; }
+        public PanelStyleJson? Tooltip { get; set; }
+        public TextColorsJson? Text { get; set; }
+        public SelectionColorsJson? Selection { get; set; }
+        public StatusBarColorsJson? StatusBar { get; set; }
+        public ScrollbarColorsJson? Scrollbar { get; set; }
+        public Dictionary<string, Dictionary<string, int[]>>? Custom { get; set; }
+    }
+
+    private class FontsJson
+    {
+        public string? Default { get; set; }
+        public string? Tooltip { get; set; }
+        public string? Title { get; set; }
+    }
+
+    private class PanelStyleJson
+    {
+        public int[]? BackgroundColor { get; set; }
+        public int[]? BorderColor { get; set; }
+        public int? BorderWidth { get; set; }
+        public int? ContentPadding { get; set; }
+    }
+
+    private class ButtonStyleJson : PanelStyleJson
+    {
+        public int[]? HoverBackgroundColor { get; set; }
+        public int[]? HoverBorderColor { get; set; }
+        public int[]? DisabledBackgroundColor { get; set; }
+        public int[]? DisabledBorderColor { get; set; }
+    }
+
+    private class TextColorsJson
+    {
+        public int[]? Primary { get; set; }
+        public int[]? Secondary { get; set; }
+        public int[]? Muted { get; set; }
+        public int[]? Error { get; set; }
+        public int[]? Warning { get; set; }
+        public int[]? Title { get; set; }
+        public int[]? Highlight { get; set; }
+        public int[]? Subtitle { get; set; }
+        public int[]? SectionHeader { get; set; }
+        public int[]? Placeholder { get; set; }
+        public int[]? Shadow { get; set; }
+    }
+
+    private class SelectionColorsJson
+    {
+        public int[]? SelectedBackground { get; set; }
+        public int[]? HoverBackground { get; set; }
+        public int[]? SelectionBorder { get; set; }
+        public int[]? HoverBorder { get; set; }
+        public int[]? InvalidDrop { get; set; }
+        public int[]? ValidDrop { get; set; }
+        public int[]? EmptySlot { get; set; }
+        public int[]? SlotHover { get; set; }
+        public int[]? CloseButton { get; set; }
+    }
+
+    private class StatusBarColorsJson
+    {
+        public int[]? ProgressFill { get; set; }
+        public int[]? ProgressBackground { get; set; }
+    }
+
+    private class ScrollbarColorsJson
+    {
+        public int[]? Track { get; set; }
+        public int[]? Thumb { get; set; }
+    }
+}
+
+public class UIThemeData
+{
+    public ThemeFonts Fonts { get; set; } = new();
+    public PanelStyle Panel { get; set; } = new();
+    public ButtonStyle Button { get; set; } = new();
+    public PanelStyle Input { get; set; } = new();
+    public PanelStyle Tooltip { get; set; } = new();
+    public TextColors Text { get; set; } = new();
+    public SelectionColors Selection { get; set; } = new();
+    public StatusBarColors StatusBar { get; set; } = new();
+    public ScrollbarColors Scrollbar { get; set; } = new();
+}
+
+public class ThemeFonts
+{
+    public SpriteFont Default { get; set; } = null!;
+    public SpriteFont Tooltip { get; set; } = null!;
+    public SpriteFont Title { get; set; } = null!;
+}
+
+public class PanelStyle
+{
+    public Color BackgroundColor { get; set; } = new Color(40, 40, 40, 220);
+    public Color BorderColor { get; set; } = new Color(80, 80, 80);
+    public int BorderWidth { get; set; } = 2;
+    public int ContentPadding { get; set; } = 16;
+}
+
+public class ButtonStyle : PanelStyle
+{
+    public Color HoverBackgroundColor { get; set; } = new Color(80, 75, 65, 240);
+    public Color HoverBorderColor { get; set; } = new Color(200, 180, 140);
+    public Color DisabledBackgroundColor { get; set; } = new Color(35, 35, 35, 200);
+    public Color DisabledBorderColor { get; set; } = new Color(50, 50, 50);
+}
+
+public class TextColors
+{
+    public Color Primary { get; set; } = Color.White;
+    public Color Secondary { get; set; } = Color.LightGray;
+    public Color Muted { get; set; } = Color.Gray;
+    public Color Error { get; set; } = Color.Red;
+    public Color Warning { get; set; } = Color.Yellow;
+    public Color Title { get; set; } = new Color(220, 200, 160);
+    public Color Highlight { get; set; } = new Color(200, 180, 140);
+    public Color Subtitle { get; set; } = new Color(160, 160, 160);
+    public Color SectionHeader { get; set; } = new Color(150, 150, 150);
+    public Color Placeholder { get; set; } = new Color(100, 100, 100);
+    public Color Shadow { get; set; } = Color.Black;
+}
+
+public class SelectionColors
+{
+    public Color SelectedBackground { get; set; } = new Color(80, 70, 50);
+    public Color HoverBackground { get; set; } = new Color(60, 60, 60);
+    public Color SelectionBorder { get; set; } = new Color(200, 180, 140);
+    public Color HoverBorder { get; set; } = new Color(150, 150, 150, 180);
+    public Color InvalidDrop { get; set; } = new Color(200, 50, 50, 180);
+    public Color ValidDrop { get; set; } = new Color(50, 200, 50, 180);
+    public Color EmptySlot { get; set; } = new Color(50, 50, 50, 150);
+    public Color SlotHover { get; set; } = new Color(60, 60, 80, 220);
+    public Color CloseButton { get; set; } = new Color(180, 60, 60);
+}
+
+public class StatusBarColors
+{
+    public Color ProgressFill { get; set; } = new Color(80, 200, 80);
+    public Color ProgressBackground { get; set; } = new Color(40, 40, 40);
+}
+
+public class ScrollbarColors
+{
+    public Color Track { get; set; } = new Color(40, 40, 40, 150);
+    public Color Thumb { get; set; } = new Color(120, 120, 120, 200);
+}

--- a/Solo/UI/Widgets/BreadcrumbWidget.cs
+++ b/Solo/UI/Widgets/BreadcrumbWidget.cs
@@ -1,0 +1,203 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Collections.Generic;
+
+namespace Solo.UI.Widgets;
+
+public class BreadcrumbWidget : Widget
+{
+    private const string Separator = " > ";
+    private const string Ellipsis = "...";
+    private const int SegmentPadding = 4;
+
+    private readonly List<BreadcrumbSegment> _segments = new();
+
+    public float FontScale { get; set; } = 1.0f;
+    public Color TextColor { get; set; } = UITheme.Text.Secondary;
+    public Color HoverColor { get; set; } = UITheme.Text.Title;
+    public Color CurrentColor { get; set; } = UITheme.Text.Primary;
+    public Color BorderColor { get; set; } = UITheme.Panel.BorderColor;
+    public int BorderHeight { get; set; } = 1;
+    public int BottomPadding { get; set; } = 8;
+
+    public event Action<int>? OnSegmentClicked;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        float textHeight = UITheme.Font.LineSpacing * FontScale;
+        return new Vector2(availableWidth, textHeight + BottomPadding + BorderHeight);
+    }
+
+    public void SetPath(IReadOnlyList<string> path)
+    {
+        _segments.Clear();
+        InvalidateMeasure();
+
+        if (path.Count == 0)
+            return;
+
+        var separatorWidth = UITheme.Font.MeasureString(Separator).X * FontScale;
+        var ellipsisWidth = UITheme.Font.MeasureString(Ellipsis).X * FontScale;
+        float availableWidth = Size.X;
+
+        float totalWidth = CalculateTotalWidth(path, separatorWidth);
+
+        if (totalWidth <= availableWidth || path.Count <= 1)
+        {
+            BuildFullPath(path, separatorWidth);
+        }
+        else
+        {
+            BuildCollapsedPath(path, separatorWidth, ellipsisWidth, availableWidth);
+        }
+    }
+
+    private float CalculateTotalWidth(IReadOnlyList<string> path, float separatorWidth)
+    {
+        float width = 0;
+        for (int i = 0; i < path.Count; i++)
+        {
+            width += UITheme.Font.MeasureString(path[i]).X * FontScale;
+            if (i < path.Count - 1)
+                width += separatorWidth;
+        }
+        return width;
+    }
+
+    private void BuildFullPath(IReadOnlyList<string> path, float separatorWidth)
+    {
+        float x = 0;
+        for (int i = 0; i < path.Count; i++)
+        {
+            var text = path[i];
+            var textWidth = UITheme.Font.MeasureString(text).X * FontScale;
+
+            _segments.Add(new BreadcrumbSegment
+            {
+                Text = text,
+                Index = i,
+                X = x,
+                Width = textWidth,
+                IsLast = i == path.Count - 1,
+                IsEllipsis = false
+            });
+
+            x += textWidth;
+            if (i < path.Count - 1)
+                x += separatorWidth;
+        }
+    }
+
+    private void BuildCollapsedPath(IReadOnlyList<string> path, float separatorWidth, float ellipsisWidth, float availableWidth)
+    {
+        var lastText = path[^1];
+        var lastWidth = UITheme.Font.MeasureString(lastText).X * FontScale;
+
+        float x = 0;
+
+        _segments.Add(new BreadcrumbSegment
+        {
+            Text = Ellipsis,
+            Index = path.Count - 2,
+            X = x,
+            Width = ellipsisWidth,
+            IsLast = false,
+            IsEllipsis = true
+        });
+
+        x += ellipsisWidth + separatorWidth;
+
+        _segments.Add(new BreadcrumbSegment
+        {
+            Text = lastText,
+            Index = path.Count - 1,
+            X = x,
+            Width = lastWidth,
+            IsLast = true,
+            IsEllipsis = false
+        });
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        var mousePos = new Point(mouseState.X, mouseState.Y);
+        var screenPos = ScreenPosition;
+
+        foreach (var segment in _segments)
+        {
+            var segmentBounds = new Rectangle(
+                (int)(screenPos.X + segment.X - SegmentPadding),
+                (int)screenPos.Y,
+                (int)(segment.Width + SegmentPadding * 2),
+                (int)Size.Y
+            );
+
+            segment.IsHovered = !segment.IsLast && segmentBounds.Contains(mousePos);
+        }
+
+        if (mouseState.LeftButton == ButtonState.Pressed &&
+            previousMouseState.LeftButton == ButtonState.Released)
+        {
+            foreach (var segment in _segments)
+            {
+                if (segment.IsHovered)
+                {
+                    OnSegmentClicked?.Invoke(segment.Index);
+                    break;
+                }
+            }
+        }
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        if (_segments.Count == 0)
+            return;
+
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
+        var screenPos = ScreenPosition;
+        float x = screenPos.X;
+        var separatorWidth = UITheme.Font.MeasureString(Separator).X * FontScale;
+
+        for (int i = 0; i < _segments.Count; i++)
+        {
+            var segment = _segments[i];
+            Color color;
+
+            if (segment.IsLast)
+                color = CurrentColor;
+            else if (segment.IsHovered)
+                color = HoverColor;
+            else
+                color = TextColor;
+
+            spriteBatch.DrawString(UITheme.Font, segment.Text, new Vector2(x, screenPos.Y), color, 0f, Vector2.Zero, FontScale, SpriteEffects.None, 0f);
+            x += segment.Width;
+
+            if (i < _segments.Count - 1)
+            {
+                spriteBatch.DrawString(UITheme.Font, Separator, new Vector2(x, screenPos.Y), TextColor, 0f, Vector2.Zero, FontScale, SpriteEffects.None, 0f);
+                x += separatorWidth;
+            }
+        }
+
+        if (BorderHeight > 0)
+        {
+            int borderY = (int)(screenPos.Y + Size.Y - BorderHeight - BottomPadding);
+            spriteBatch.Draw(pixel, new Rectangle((int)screenPos.X, borderY, (int)Size.X, BorderHeight), BorderColor);
+        }
+    }
+
+    private class BreadcrumbSegment
+    {
+        public string Text { get; set; } = string.Empty;
+        public int Index { get; set; }
+        public float X { get; set; }
+        public float Width { get; set; }
+        public bool IsLast { get; set; }
+        public bool IsHovered { get; set; }
+        public bool IsEllipsis { get; set; }
+    }
+}

--- a/Solo/UI/Widgets/ButtonWidget.cs
+++ b/Solo/UI/Widgets/ButtonWidget.cs
@@ -1,0 +1,118 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class ButtonWidget : PanelWidget
+{
+    private bool _isHovered;
+    private string _text = string.Empty;
+
+    public ButtonWidget()
+    {
+        ShowCloseButton = false;
+        BackgroundColor = UITheme.Button.BackgroundColor;
+        BorderColor = UITheme.Button.BorderColor;
+        BorderWidth = UITheme.Button.BorderWidth;
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            _text = value;
+            if (AutoSize)
+                FitToText();
+            InvalidateMeasure();
+        }
+    }
+
+    public bool AutoSize { get; set; } = true;
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color HoverTextColor { get; set; } = UITheme.Text.Title;
+    public Color HoverBackgroundColor { get; set; } = UITheme.Button.HoverBackgroundColor;
+    public Color HoverBorderColor { get; set; } = UITheme.Button.HoverBorderColor;
+    public Color DisabledTextColor { get; set; } = UITheme.Text.Muted;
+    public Color DisabledBackgroundColor { get; set; } = UITheme.Button.DisabledBackgroundColor;
+    public Color DisabledBorderColor { get; set; } = UITheme.Button.DisabledBorderColor;
+
+    public bool IsHovered => _isHovered && Enabled;
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        var mousePoint = new Point(mouseState.X, mouseState.Y);
+        _isHovered = Enabled && Bounds.Contains(mousePoint);
+
+        base.UpdateCore(gameTime, mouseState, previousMouseState);
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var originalBackgroundColor = BackgroundColor;
+        var originalBorderColor = BorderColor;
+
+        if (!Enabled)
+        {
+            BackgroundColor = DisabledBackgroundColor;
+            BorderColor = DisabledBorderColor;
+        }
+        else if (_isHovered)
+        {
+            BackgroundColor = HoverBackgroundColor;
+            BorderColor = HoverBorderColor;
+        }
+
+        base.RenderCore(spriteBatch);
+
+        BackgroundColor = originalBackgroundColor;
+        BorderColor = originalBorderColor;
+
+        // Draw text centered
+        if (!string.IsNullOrEmpty(Text))
+        {
+            var textSize = UITheme.Font.MeasureString(Text);
+            var textPos = ScreenPosition + (Size - textSize) / 2;
+            var currentTextColor = !Enabled ? DisabledTextColor : (_isHovered ? HoverTextColor : TextColor);
+            spriteBatch.DrawString(UITheme.Font, Text, textPos, currentTextColor);
+        }
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        if (AutoSize && !string.IsNullOrEmpty(_text))
+        {
+            var textSize = UITheme.Font.MeasureString(_text);
+            var padding = UITheme.Button.ContentPadding;
+            return new Vector2(
+                textSize.X + padding * 2f + BorderWidth * 2f,
+                textSize.Y + padding * 2f + BorderWidth * 2f
+            );
+        }
+
+        return Size;
+    }
+
+    private void FitToText()
+    {
+        if (string.IsNullOrEmpty(_text))
+            return;
+
+        var textSize = UITheme.Font.MeasureString(_text);
+        var padding = UITheme.Button.ContentPadding;
+        Size = new Vector2(
+            textSize.X + (float)padding * 2f + (float)BorderWidth * 2f,
+            textSize.Y + (float)padding * 2f + (float)BorderWidth * 2f
+        );
+    }
+
+    protected override void OnMouseClick(Point mousePosition)
+    {
+        OnClick?.Invoke();
+        base.OnMouseClick(mousePosition);
+    }
+
+    public event Action? OnClick;
+}

--- a/Solo/UI/Widgets/CheckboxWidget.cs
+++ b/Solo/UI/Widgets/CheckboxWidget.cs
@@ -1,0 +1,117 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class CheckboxWidget : Widget
+{
+    private bool _isHovered;
+    private string _label = string.Empty;
+
+    public string Label
+    {
+        get => _label;
+        set
+        {
+            if (_label != value)
+            {
+                _label = value;
+                InvalidateMeasure();
+            }
+        }
+    }
+    public bool Checked { get; set; }
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color BoxBorderColor { get; set; } = UITheme.Button.BorderColor;
+    public Color BoxBackgroundColor { get; set; } = UITheme.Button.BackgroundColor;
+    public Color CheckColor { get; set; } = UITheme.Text.Highlight;
+    public Color HoverBorderColor { get; set; } = UITheme.Button.HoverBorderColor;
+
+    public event Action<bool>? OnChanged;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        float boxSize = UITheme.LineHeight;
+        float gap = 8;
+        float textWidth = string.IsNullOrEmpty(_label) ? 0 : UITheme.Font.MeasureString(_label).X;
+        float width = boxSize + gap + textWidth;
+        float height = Math.Max(UITheme.LineHeight, UITheme.Font.LineSpacing);
+        return new Vector2(width, height);
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        _isHovered = Bounds.Contains(mouseState.X, mouseState.Y);
+
+        if (_isHovered &&
+            mouseState.LeftButton == ButtonState.Pressed &&
+            previousMouseState.LeftButton == ButtonState.Released)
+        {
+            Checked = !Checked;
+            OnChanged?.Invoke(Checked);
+        }
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pos = ScreenPosition;
+        int boxSize = UITheme.LineHeight;
+        int border = 2;
+        int padding = 8;
+        float labelX = pos.X + boxSize + padding;
+        float centerY = pos.Y + (Size.Y - boxSize) / 2;
+
+        var borderColor = _isHovered ? HoverBorderColor : BoxBorderColor;
+
+        // Box background
+        var boxRect = new Rectangle((int)pos.X, (int)centerY, boxSize, boxSize);
+        spriteBatch.Draw(pixel, boxRect, BoxBackgroundColor);
+
+        // Box border
+        spriteBatch.Draw(pixel, new Rectangle(boxRect.X, boxRect.Y, boxRect.Width, border), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(boxRect.X, boxRect.Bottom - border, boxRect.Width, border), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(boxRect.X, boxRect.Y, border, boxRect.Height), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(boxRect.Right - border, boxRect.Y, border, boxRect.Height), borderColor);
+
+        // Checkmark (drawn as two diagonal lines)
+        if (Checked)
+        {
+            int inset = boxSize / 4;
+            int thickness = Math.Max(2, boxSize / 8);
+            int innerSize = boxSize - inset * 2;
+
+            // Short leg of checkmark (bottom-left to mid)
+            int shortLen = innerSize / 3;
+            for (int i = 0; i < shortLen; i++)
+            {
+                int x = boxRect.X + inset + i;
+                int y = boxRect.Y + inset + innerSize - shortLen + i;
+                spriteBatch.Draw(pixel, new Rectangle(x, y, thickness, thickness), CheckColor);
+            }
+
+            // Long leg of checkmark (mid to top-right)
+            int longLen = innerSize - shortLen;
+            for (int i = 0; i <= longLen; i++)
+            {
+                int x = boxRect.X + inset + shortLen + i;
+                int y = boxRect.Y + inset + innerSize - i;
+                spriteBatch.Draw(pixel, new Rectangle(x, y, thickness, thickness), CheckColor);
+            }
+        }
+
+        // Label text
+        if (!string.IsNullOrEmpty(Label))
+        {
+            var textSize = UITheme.Font.MeasureString(Label);
+            var textPos = new Vector2(labelX, pos.Y + (Size.Y - textSize.Y) / 2);
+            spriteBatch.DrawString(UITheme.Font, Label, textPos, TextColor);
+        }
+    }
+
+    protected override void OnMouseClick(Point mousePosition)
+    {
+    }
+}

--- a/Solo/UI/Widgets/ImageWidget.cs
+++ b/Solo/UI/Widgets/ImageWidget.cs
@@ -1,0 +1,66 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Solo.UI.Widgets;
+
+public class ImageWidget : Widget
+{
+    private Texture2D? _texture;
+
+    public ImageWidget()
+    {
+    }
+
+    public Texture2D? Texture
+    {
+        get => _texture;
+        set
+        {
+            if (_texture != value)
+            {
+                _texture = value;
+                InvalidateMeasure();
+            }
+        }
+    }
+    public Rectangle? SourceRectangle { get; set; }
+    public Color Tint { get; set; } = Color.White;
+    public bool ScaleToFit { get; set; } = true;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        if (ScaleToFit)
+            return Size;
+
+        if (_texture != null)
+            return new Vector2(_texture.Width, _texture.Height);
+
+        return Size;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        if (Texture == null)
+            return;
+
+        var destRect = Bounds;
+
+        if (!ScaleToFit)
+        {
+            var sourceSize = SourceRectangle?.Size ?? new Point(Texture.Width, Texture.Height);
+            destRect = new Rectangle(
+                (int)ScreenPosition.X,
+                (int)ScreenPosition.Y,
+                sourceSize.X,
+                sourceSize.Y
+            );
+        }
+
+        spriteBatch.Draw(
+            Texture,
+            destRect,
+            SourceRectangle,
+            Tint
+        );
+    }
+}

--- a/Solo/UI/Widgets/LabelWidget.cs
+++ b/Solo/UI/Widgets/LabelWidget.cs
@@ -1,0 +1,186 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Solo.UI.Widgets;
+
+public class LabelWidget : Widget
+{
+    private string _text = string.Empty;
+    private string[]? _wrappedLines;
+    private float _lastWrapWidth;
+
+    public LabelWidget()
+    {
+    }
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                _wrappedLines = null;
+                InvalidateMeasure();
+            }
+        }
+    }
+
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public bool CenterHorizontally { get; set; } = false;
+    public bool CenterVertically { get; set; } = false;
+    public bool WordWrap { get; set; } = false;
+
+    public float MeasureTextHeight()
+    {
+        if (string.IsNullOrEmpty(Text))
+            return 0;
+
+        if (!WordWrap)
+            return UITheme.Font.LineSpacing;
+
+        var lines = WrapText(Text, Size.X);
+        return lines.Length * UITheme.Font.LineSpacing;
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        if (string.IsNullOrEmpty(Text))
+            return Vector2.Zero;
+
+        if (!WordWrap)
+        {
+            var textSize = UITheme.Font.MeasureString(Text);
+            float width = CenterHorizontally ? availableWidth : textSize.X;
+            return new Vector2(width, UITheme.Font.LineSpacing);
+        }
+
+        var wrappedLines = WrapText(Text, availableWidth);
+        return new Vector2(availableWidth, wrappedLines.Length * UITheme.Font.LineSpacing);
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        if (string.IsNullOrEmpty(Text))
+            return;
+
+        if (WordWrap)
+        {
+            RenderWrapped(spriteBatch);
+        }
+        else
+        {
+            RenderSingleLine(spriteBatch);
+        }
+    }
+
+    private void RenderSingleLine(SpriteBatch spriteBatch)
+    {
+        var textSize = UITheme.Font.MeasureString(Text);
+        var position = ScreenPosition;
+
+        if (CenterHorizontally)
+            position.X += (Size.X - textSize.X) / 2;
+
+        if (CenterVertically)
+            position.Y += (Size.Y - textSize.Y) / 2;
+
+        spriteBatch.DrawString(UITheme.Font, Text, position, TextColor);
+    }
+
+    private void RenderWrapped(SpriteBatch spriteBatch)
+    {
+        // Re-wrap if width changed or cache is invalid
+        if (_wrappedLines == null || Math.Abs(_lastWrapWidth - Size.X) > 0.1f)
+        {
+            _wrappedLines = WrapText(Text, Size.X);
+            _lastWrapWidth = Size.X;
+        }
+
+        var position = ScreenPosition;
+        float lineHeight = UITheme.Font.LineSpacing;
+
+        if (CenterVertically)
+        {
+            float totalHeight = _wrappedLines.Length * lineHeight;
+            position.Y += (Size.Y - totalHeight) / 2;
+        }
+
+        foreach (var line in _wrappedLines)
+        {
+            var linePos = position;
+
+            if (CenterHorizontally)
+            {
+                var lineWidth = UITheme.Font.MeasureString(line).X;
+                linePos.X += (Size.X - lineWidth) / 2;
+            }
+
+            spriteBatch.DrawString(UITheme.Font, line, linePos, TextColor);
+            position.Y += lineHeight;
+        }
+    }
+
+    private string[] WrapText(string text, float maxWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+            return Array.Empty<string>();
+
+        var lines = new List<string>();
+        var paragraphs = text.Split('\n');
+
+        foreach (var paragraph in paragraphs)
+        {
+            if (string.IsNullOrEmpty(paragraph))
+            {
+                lines.Add(string.Empty);
+                continue;
+            }
+
+            var words = paragraph.Split(' ');
+            var currentLine = new StringBuilder();
+
+            foreach (var word in words)
+            {
+                if (currentLine.Length == 0)
+                {
+                    // First word on line
+                    if (UITheme.Font.MeasureString(word).X > maxWidth)
+                    {
+                        // Word is too long, just add it anyway
+                        lines.Add(word);
+                    }
+                    else
+                    {
+                        currentLine.Append(word);
+                    }
+                }
+                else
+                {
+                    var testLine = currentLine + " " + word;
+                    if (UITheme.Font.MeasureString(testLine).X <= maxWidth)
+                    {
+                        currentLine.Append(' ');
+                        currentLine.Append(word);
+                    }
+                    else
+                    {
+                        // Line would be too long, start new line
+                        lines.Add(currentLine.ToString());
+                        currentLine.Clear();
+                        currentLine.Append(word);
+                    }
+                }
+            }
+
+            if (currentLine.Length > 0)
+                lines.Add(currentLine.ToString());
+        }
+
+        return lines.ToArray();
+    }
+}

--- a/Solo/UI/Widgets/MenuItemWidget.cs
+++ b/Solo/UI/Widgets/MenuItemWidget.cs
@@ -1,0 +1,111 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class MenuItemWidget : Widget
+{
+    private bool _isHovered;
+    private bool _isSelected;
+    private string _text = string.Empty;
+
+    public string Text
+    {
+        get => _text;
+        set
+        {
+            if (_text != value)
+            {
+                _text = value;
+                InvalidateMeasure();
+            }
+        }
+    }
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color HoverTextColor { get; set; } = UITheme.Text.Title;
+    public Color SelectedTextColor { get; set; } = UITheme.Text.Title;
+    public Color BackgroundColor { get; set; } = Color.Transparent;
+    public Color HoverBackgroundColor { get; set; } = UITheme.Selection.HoverBackground;
+    public Color SelectedBackgroundColor { get; set; } = UITheme.Selection.SelectedBackground;
+    public int Padding { get; set; } = 8;
+    public bool CenterHorizontally { get; set; }
+
+    public bool IsSelected
+    {
+        get => _isSelected;
+        set => _isSelected = value;
+    }
+
+    public event Action? OnClick;
+    public event Action? OnHover;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return new Vector2(availableWidth, UITheme.MenuItemHeight);
+    }
+
+    public void Click()
+    {
+        OnClick?.Invoke();
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        var wasHovered = _isHovered;
+        _isHovered = Bounds.Contains(mouseState.X, mouseState.Y);
+
+        if (_isHovered && !wasHovered)
+            OnHover?.Invoke();
+
+        if (_isHovered &&
+            mouseState.LeftButton == ButtonState.Pressed &&
+            previousMouseState.LeftButton == ButtonState.Released)
+        {
+            OnClick?.Invoke();
+        }
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
+        var bounds = Bounds;
+
+        Color bgColor;
+        Color textColor;
+
+        if (_isSelected)
+        {
+            bgColor = SelectedBackgroundColor;
+            textColor = SelectedTextColor;
+        }
+        else if (_isHovered)
+        {
+            bgColor = HoverBackgroundColor;
+            textColor = HoverTextColor;
+        }
+        else
+        {
+            bgColor = BackgroundColor;
+            textColor = TextColor;
+        }
+
+        if (bgColor != Color.Transparent)
+            spriteBatch.Draw(pixel, bounds, bgColor);
+
+        if (!string.IsNullOrEmpty(Text))
+        {
+            var textSize = UITheme.Font.MeasureString(Text);
+            float textX = CenterHorizontally
+                ? bounds.X + (bounds.Width - textSize.X) / 2
+                : bounds.X + Padding;
+            var textPos = new Vector2(
+                textX,
+                bounds.Y + (bounds.Height - textSize.Y) / 2
+            );
+            spriteBatch.DrawString(UITheme.Font, Text, textPos, textColor);
+        }
+    }
+
+}

--- a/Solo/UI/Widgets/MetricRowWidget.cs
+++ b/Solo/UI/Widgets/MetricRowWidget.cs
@@ -1,0 +1,37 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Solo.UI.Widgets;
+
+public class MetricRowWidget : Widget
+{
+    public MetricRowWidget()
+    {
+    }
+
+    public string Label { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public Color LabelColor { get; set; } = UITheme.Text.Secondary;
+    public Color ValueColor { get; set; } = UITheme.Text.Primary;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pos = ScreenPosition;
+
+        // Label on left
+        spriteBatch.DrawString(UITheme.Font, Label, pos, LabelColor);
+
+        // Value on right
+        if (!string.IsNullOrEmpty(Value))
+        {
+            var valueSize = UITheme.Font.MeasureString(Value);
+            float valueX = pos.X + Size.X - valueSize.X;
+            spriteBatch.DrawString(UITheme.Font, Value, new Vector2(valueX, pos.Y), ValueColor);
+        }
+    }
+}

--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -1,0 +1,342 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class PanelWidget : Widget
+{
+    private const int CloseButtonSize = 20;
+    private const int CloseButtonMargin = 6;
+    private const int ScrollbarWidth = 6;
+    private const int ScrollSpeed = 30;
+
+    private static Texture2D? _pixelTexture;
+
+    private float _scrollOffset;
+    private int _previousScrollWheelValue;
+
+    public PanelWidget()
+    {
+    }
+
+    public Color BackgroundColor { get; set; } = UITheme.Panel.BackgroundColor;
+    public Color BorderColor { get; set; } = UITheme.Panel.BorderColor;
+    public int BorderWidth { get; set; } = 2;
+    public bool ShowCloseButton { get; set; } = true;
+    public bool Scrollable { get; set; }
+    public int ContentPadding { get; set; } = 16;
+
+    public float ScrollOffset
+    {
+        get => _scrollOffset;
+        set => _scrollOffset = Math.Max(0, Math.Min(value, MaxScrollOffset));
+    }
+
+    public event Action? OnCloseClicked;
+
+    protected override Vector2 ChildRenderOffset
+    {
+        get
+        {
+            int topOffset = ShowCloseButton ? CloseButtonSize + CloseButtonMargin : ContentPadding;
+            float scrollAdjustment = Scrollable ? -_scrollOffset : 0;
+            return new Vector2(ContentPadding, topOffset + scrollAdjustment);
+        }
+    }
+
+    protected Rectangle CloseButtonBounds
+    {
+        get
+        {
+            var bounds = Bounds;
+            return new Rectangle(
+                bounds.Right - CloseButtonSize - CloseButtonMargin,
+                bounds.Y + CloseButtonMargin,
+                CloseButtonSize,
+                CloseButtonSize
+            );
+        }
+    }
+
+    /// <summary>
+    /// The area where scrollable content is rendered (excludes close button area and padding).
+    /// </summary>
+    protected Rectangle ContentBounds
+    {
+        get
+        {
+            var bounds = Bounds;
+            int topOffset = ShowCloseButton ? CloseButtonSize + CloseButtonMargin : ContentPadding;
+            return new Rectangle(
+                bounds.X + ContentPadding,
+                bounds.Y + topOffset,
+                bounds.Width - ContentPadding * 2 - (Scrollable ? ScrollbarWidth : 0),
+                bounds.Height - topOffset - ContentPadding
+            );
+        }
+    }
+
+    /// <summary>
+    /// Total height of all children content.
+    /// </summary>
+    protected virtual float ContentHeight
+    {
+        get
+        {
+            float maxY = 0;
+            foreach (var child in Children)
+            {
+                float childBottom = child.Position.Y + child.Size.Y;
+                if (childBottom > maxY)
+                    maxY = childBottom;
+            }
+            return maxY;
+        }
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        float horizontalChrome = ContentPadding * 2 + BorderWidth * 2 + (Scrollable ? ScrollbarWidth : 0);
+        float childAvailableWidth = Math.Max(0, availableWidth - horizontalChrome);
+        float childAvailableHeight = Math.Max(0, availableHeight);
+
+        float maxRight = 0;
+        float maxBottom = 0;
+
+        foreach (var child in Children)
+        {
+            if (!child.Visible)
+                continue;
+
+            child.Measure(childAvailableWidth, childAvailableHeight);
+
+            float childRight = child.Position.X + child.DesiredSize.X;
+            float childBottom = child.Position.Y + child.DesiredSize.Y;
+
+            if (childRight > maxRight)
+                maxRight = childRight;
+            if (childBottom > maxBottom)
+                maxBottom = childBottom;
+        }
+
+        float topOffset = ShowCloseButton ? CloseButtonSize + CloseButtonMargin : ContentPadding;
+        float width = maxRight + horizontalChrome;
+        float height = topOffset + maxBottom + ContentPadding + BorderWidth * 2;
+
+        return new Vector2(width, height);
+    }
+
+    protected override void ArrangeCore(Vector2 finalSize)
+    {
+        foreach (var child in Children)
+        {
+            if (!child.Visible)
+                continue;
+
+            child.Arrange(child.DesiredSize);
+        }
+    }
+
+    /// <summary>
+    /// Maximum scroll offset based on content height vs visible area.
+    /// </summary>
+    protected float MaxScrollOffset
+    {
+        get
+        {
+            if (!Scrollable)
+                return 0;
+            float visibleHeight = ContentBounds.Height;
+            return Math.Max(0, ContentHeight - visibleHeight);
+        }
+    }
+
+    protected static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        base.UpdateCore(gameTime, mouseState, previousMouseState);
+
+        if (ShowCloseButton &&
+            mouseState.LeftButton == ButtonState.Pressed &&
+            previousMouseState.LeftButton == ButtonState.Released)
+        {
+            if (CloseButtonBounds.Contains(mouseState.X, mouseState.Y))
+            {
+                OnCloseClicked?.Invoke();
+                Visible = false;
+            }
+        }
+
+        // Handle mouse wheel scrolling
+        if (Scrollable && Bounds.Contains(mouseState.X, mouseState.Y))
+        {
+            int scrollDelta = mouseState.ScrollWheelValue - _previousScrollWheelValue;
+            if (scrollDelta != 0)
+            {
+                ScrollOffset -= scrollDelta / 120f * ScrollSpeed;
+            }
+        }
+        _previousScrollWheelValue = mouseState.ScrollWheelValue;
+    }
+
+    public override void Render(SpriteBatch spriteBatch)
+    {
+        if (!Visible)
+            return;
+
+        RenderCore(spriteBatch);
+
+        if (Scrollable)
+        {
+            RenderScrollableChildren(spriteBatch);
+        }
+        else
+        {
+            foreach (var child in Children)
+                child.Render(spriteBatch);
+        }
+    }
+
+    private void RenderScrollableChildren(SpriteBatch spriteBatch)
+    {
+        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var contentBounds = ContentBounds;
+
+        // End current batch to flush state, then save
+        spriteBatch.End();
+
+        var originalScissor = spriteBatch.GraphicsDevice.ScissorRectangle;
+        var originalRasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
+
+        // Set up scissor rectangle for clipping (scissor is in screen space, so scale it)
+        var scale = UITheme.UIScale;
+        var sampler = scale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
+        var matrix = scale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
+        var rasterizerState = new RasterizerState { ScissorTestEnable = true };
+        spriteBatch.GraphicsDevice.ScissorRectangle = new Rectangle(
+            (int)(contentBounds.X * scale),
+            (int)(contentBounds.Y * scale),
+            (int)(contentBounds.Width * scale),
+            (int)(contentBounds.Height * scale)
+        );
+
+        spriteBatch.Begin(
+            SpriteSortMode.Deferred,
+            BlendState.AlphaBlend,
+            sampler,
+            null,
+            rasterizerState,
+            null,
+            matrix
+        );
+
+        // Render children (they will use ChildRenderOffset for positioning)
+        foreach (var child in Children)
+            child.Render(spriteBatch);
+
+        spriteBatch.End();
+
+        // Restore original state
+        spriteBatch.GraphicsDevice.ScissorRectangle = originalScissor;
+
+        spriteBatch.Begin(
+            SpriteSortMode.Deferred,
+            BlendState.AlphaBlend,
+            sampler,
+            null,
+            originalRasterizerState,
+            null,
+            matrix
+        );
+
+        // Render scrollbar
+        RenderScrollbar(spriteBatch, pixel, contentBounds);
+    }
+
+    private void RenderScrollbar(SpriteBatch spriteBatch, Texture2D pixel, Rectangle contentBounds)
+    {
+        if (MaxScrollOffset <= 0)
+            return;
+
+        int scrollbarX = Bounds.Right - ContentPadding - ScrollbarWidth + 4;
+        int scrollbarHeight = contentBounds.Height;
+
+        // Track
+        spriteBatch.Draw(pixel, new Rectangle(scrollbarX, contentBounds.Y, ScrollbarWidth, scrollbarHeight), UITheme.Scrollbar.Track);
+
+        // Thumb
+        float thumbRatio = contentBounds.Height / (contentBounds.Height + MaxScrollOffset);
+        int thumbHeight = Math.Max(20, (int)(scrollbarHeight * thumbRatio));
+        float scrollRatio = MaxScrollOffset > 0 ? _scrollOffset / MaxScrollOffset : 0;
+        int thumbY = contentBounds.Y + (int)((scrollbarHeight - thumbHeight) * scrollRatio);
+
+        spriteBatch.Draw(pixel, new Rectangle(scrollbarX, thumbY, ScrollbarWidth, thumbHeight), UITheme.Scrollbar.Thumb);
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var bounds = Bounds;
+
+        // Draw background
+        spriteBatch.Draw(pixel, bounds, BackgroundColor);
+
+        // Draw border
+        if (BorderWidth > 0)
+        {
+            // Top
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, bounds.Width, BorderWidth), BorderColor);
+            // Bottom
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Bottom - BorderWidth, bounds.Width, BorderWidth), BorderColor);
+            // Left
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, BorderWidth, bounds.Height), BorderColor);
+            // Right
+            spriteBatch.Draw(pixel, new Rectangle(bounds.Right - BorderWidth, bounds.Y, BorderWidth, bounds.Height), BorderColor);
+        }
+
+        // Draw close button
+        if (ShowCloseButton)
+        {
+            RenderCloseButton(spriteBatch, pixel);
+        }
+    }
+
+    private void RenderCloseButton(SpriteBatch spriteBatch, Texture2D pixel)
+    {
+        var closeBounds = CloseButtonBounds;
+        var closeColor = UITheme.Selection.CloseButton;
+        var xColor = UITheme.Text.Primary;
+
+        // Button background
+        spriteBatch.Draw(pixel, closeBounds, closeColor);
+
+        // Draw X
+        int padding = 4;
+        int thickness = 2;
+
+        // Draw X as two diagonal lines using small rectangles
+        for (int i = 0; i < closeBounds.Width - padding * 2; i++)
+        {
+            // Top-left to bottom-right diagonal
+            int x1 = closeBounds.X + padding + i;
+            int y1 = closeBounds.Y + padding + i;
+            spriteBatch.Draw(pixel, new Rectangle(x1, y1, thickness, thickness), xColor);
+
+            // Top-right to bottom-left diagonal
+            int x2 = closeBounds.Right - padding - i - thickness;
+            int y2 = closeBounds.Y + padding + i;
+            spriteBatch.Draw(pixel, new Rectangle(x2, y2, thickness, thickness), xColor);
+        }
+    }
+}

--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -12,8 +12,6 @@ public class PanelWidget : Widget
     private const int ScrollbarWidth = 6;
     private const int ScrollSpeed = 30;
 
-    private static Texture2D? _pixelTexture;
-
     private float _scrollOffset;
     private int _previousScrollWheelValue;
 
@@ -153,16 +151,6 @@ public class PanelWidget : Widget
         }
     }
 
-    protected static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
-    }
-
     protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
     {
         base.UpdateCore(gameTime, mouseState, previousMouseState);
@@ -210,7 +198,7 @@ public class PanelWidget : Widget
 
     private void RenderScrollableChildren(SpriteBatch spriteBatch)
     {
-        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var contentBounds = ContentBounds;
 
         // End current batch to flush state, then save
@@ -286,7 +274,7 @@ public class PanelWidget : Widget
 
     protected override void RenderCore(SpriteBatch spriteBatch)
     {
-        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var bounds = Bounds;
 
         // Draw background

--- a/Solo/UI/Widgets/PointDistributorWidget.cs
+++ b/Solo/UI/Widgets/PointDistributorWidget.cs
@@ -1,0 +1,187 @@
+using Microsoft.Xna.Framework;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class PointDistributorWidget : Widget
+{
+    private readonly ButtonWidget _minusButton;
+    private readonly ButtonWidget _plusButton;
+    private readonly LabelWidget _nameLabel;
+    private readonly LabelWidget _valueLabel;
+    private readonly LabelWidget _bonusLabel;
+
+    private int _value;
+    private readonly float _bonusPerPoint;
+
+    public string SkillName { get; }
+    public int Value
+    {
+        get => _value;
+        set
+        {
+            _value = value;
+            UpdateDisplay();
+        }
+    }
+
+    public bool CanDecrease
+    {
+        get => _minusButton.Enabled;
+        set => _minusButton.Enabled = value;
+    }
+
+    public bool CanIncrease
+    {
+        get => _plusButton.Enabled;
+        set => _plusButton.Enabled = value;
+    }
+
+    public event Action? OnValueChanged;
+
+    public PointDistributorWidget(string skillName, float bonusPerPoint)
+    {
+        SkillName = skillName;
+        _bonusPerPoint = bonusPerPoint;
+
+        _nameLabel = new LabelWidget
+        {
+            Text = skillName,
+            TextColor = UITheme.Text.Primary
+        };
+        AddChild(_nameLabel);
+
+        _minusButton = new ButtonWidget
+        {
+            AutoSize = false,
+            Text = "-",
+            Enabled = false
+        };
+        _minusButton.OnClick += OnMinusClicked;
+        AddChild(_minusButton);
+
+        _valueLabel = new LabelWidget
+        {
+            Text = "0",
+            TextColor = UITheme.Text.Title,
+            CenterHorizontally = true
+        };
+        AddChild(_valueLabel);
+
+        _plusButton = new ButtonWidget
+        {
+            AutoSize = false,
+            Text = "+"
+        };
+        _plusButton.OnClick += OnPlusClicked;
+        AddChild(_plusButton);
+
+        _bonusLabel = new LabelWidget
+        {
+            Text = "(+0%)",
+            TextColor = UITheme.Text.Secondary
+        };
+        AddChild(_bonusLabel);
+
+        UpdateDisplay();
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        float maxRight = 0;
+        float maxBottom = 0;
+
+        foreach (var child in Children)
+        {
+            if (!child.Visible)
+                continue;
+
+            child.Measure(availableWidth, availableHeight);
+
+            float childRight = child.Position.X + child.DesiredSize.X;
+            float childBottom = child.Position.Y + child.DesiredSize.Y;
+
+            if (childRight > maxRight)
+                maxRight = childRight;
+            if (childBottom > maxBottom)
+                maxBottom = childBottom;
+        }
+
+        return new Vector2(maxRight, maxBottom);
+    }
+
+    protected override void ArrangeCore(Vector2 finalSize)
+    {
+        int lh = UITheme.LineHeight;
+        int btnSize = lh + 8;
+        int labelVPad = (int)(finalSize.Y - lh) / 2;
+        int nameWidth = Math.Max(120, lh * 6);
+        int gap = lh / 2;
+        int valueWidth = Math.Max(30, lh * 2);
+        int bonusWidth = Math.Max(80, lh * 4);
+
+        int x = 0;
+        _nameLabel.Position = new Vector2(x, labelVPad);
+        _nameLabel.Arrange(new Vector2(nameWidth, lh));
+        x += nameWidth + gap;
+
+        _minusButton.Position = new Vector2(x, 0);
+        _minusButton.Arrange(new Vector2(btnSize, finalSize.Y));
+        x += btnSize + gap / 2;
+
+        _valueLabel.Position = new Vector2(x, labelVPad);
+        _valueLabel.Arrange(new Vector2(valueWidth, lh));
+        x += valueWidth + gap / 2;
+
+        _plusButton.Position = new Vector2(x, 0);
+        _plusButton.Arrange(new Vector2(btnSize, finalSize.Y));
+        x += btnSize + gap;
+
+        _bonusLabel.Position = new Vector2(x, labelVPad);
+        _bonusLabel.Arrange(new Vector2(bonusWidth, lh));
+    }
+
+    private void OnMinusClicked()
+    {
+        if (_value > 0)
+        {
+            _value--;
+            UpdateDisplay();
+            OnValueChanged?.Invoke();
+        }
+    }
+
+    private void OnPlusClicked()
+    {
+        _value++;
+        UpdateDisplay();
+        OnValueChanged?.Invoke();
+    }
+
+    private void UpdateDisplay()
+    {
+        _valueLabel.Text = _value.ToString();
+
+        int bonusPercent = (int)(_value * _bonusPerPoint * 100);
+        _bonusLabel.Text = $"(+{bonusPercent}%)";
+        _bonusLabel.TextColor = bonusPercent > 0 ? UITheme.StatusBar.ProgressFill : UITheme.Text.Secondary;
+
+        _minusButton.Enabled = _value > 0;
+    }
+
+    public void HandleKeyboardInput(bool leftPressed, bool rightPressed)
+    {
+        if (leftPressed && CanDecrease && _value > 0)
+        {
+            _value--;
+            UpdateDisplay();
+            OnValueChanged?.Invoke();
+        }
+        else if (rightPressed && CanIncrease)
+        {
+            _value++;
+            UpdateDisplay();
+            OnValueChanged?.Invoke();
+        }
+    }
+}

--- a/Solo/UI/Widgets/ProgressBarWidget.cs
+++ b/Solo/UI/Widgets/ProgressBarWidget.cs
@@ -6,8 +6,6 @@ namespace Solo.UI.Widgets;
 
 public class ProgressBarWidget : Widget
 {
-    private static Texture2D? _pixelTexture;
-
     public ProgressBarWidget()
     {
     }
@@ -21,16 +19,6 @@ public class ProgressBarWidget : Widget
     public Color TextColor { get; set; } = UITheme.Text.Primary;
     public Color TextShadowColor { get; set; } = UITheme.Text.Shadow;
 
-    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
-    }
-
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
         return Size;
@@ -38,7 +26,7 @@ public class ProgressBarWidget : Widget
 
     protected override void RenderCore(SpriteBatch spriteBatch)
     {
-        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var bounds = Bounds;
 
         // Background

--- a/Solo/UI/Widgets/ProgressBarWidget.cs
+++ b/Solo/UI/Widgets/ProgressBarWidget.cs
@@ -1,0 +1,74 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class ProgressBarWidget : Widget
+{
+    private static Texture2D? _pixelTexture;
+
+    public ProgressBarWidget()
+    {
+    }
+
+    public float Progress { get; set; }
+    public float MaxProgress { get; set; } = 100f;
+    public Color FillColor { get; set; } = UITheme.StatusBar.ProgressFill;
+    public Color BackgroundColor { get; set; } = UITheme.StatusBar.ProgressBackground;
+    public Color BorderColor { get; set; } = UITheme.Panel.BorderColor;
+    public string? OverlayText { get; set; }
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color TextShadowColor { get; set; } = UITheme.Text.Shadow;
+
+    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var bounds = Bounds;
+
+        // Background
+        spriteBatch.Draw(pixel, bounds, BackgroundColor);
+
+        // Fill
+        float ratio = MaxProgress > 0 ? Progress / MaxProgress : 0;
+        int fillWidth = (int)(bounds.Width * Math.Clamp(ratio, 0, 1));
+        if (fillWidth > 0)
+        {
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, fillWidth, bounds.Height), FillColor);
+        }
+
+        // Border
+        spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, bounds.Width, 1), BorderColor);
+        spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Bottom - 1, bounds.Width, 1), BorderColor);
+        spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, 1, bounds.Height), BorderColor);
+        spriteBatch.Draw(pixel, new Rectangle(bounds.Right - 1, bounds.Y, 1, bounds.Height), BorderColor);
+
+        // Overlay text
+        if (!string.IsNullOrEmpty(OverlayText))
+        {
+            var textSize = UITheme.Font.MeasureString(OverlayText);
+            float textX = bounds.X + (bounds.Width - textSize.X) / 2;
+            float textY = bounds.Y + (bounds.Height - textSize.Y) / 2;
+
+            // Shadow
+            spriteBatch.DrawString(UITheme.Font, OverlayText, new Vector2(textX + 1, textY + 1), TextShadowColor);
+            // Text
+            spriteBatch.DrawString(UITheme.Font, OverlayText, new Vector2(textX, textY), TextColor);
+        }
+    }
+}

--- a/Solo/UI/Widgets/SelectableListWidget.cs
+++ b/Solo/UI/Widgets/SelectableListWidget.cs
@@ -8,7 +8,6 @@ namespace Solo.UI.Widgets;
 
 public class SelectableListWidget : PanelWidget
 {
-    private static Texture2D? _pixelTexture;
     private int _hoveredIndex = -1;
 
     public SelectableListWidget()
@@ -47,16 +46,6 @@ public class SelectableListWidget : PanelWidget
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
         return new Vector2(availableWidth, Items.Count * ItemHeight);
-    }
-
-    private static Texture2D GetListPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
     }
 
     public void SelectNext()
@@ -118,7 +107,7 @@ public class SelectableListWidget : PanelWidget
             return;
 
         // Render panel background/border
-        var pixel = GetListPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         spriteBatch.Draw(pixel, Bounds, BackgroundColor);
 
         if (BorderWidth > 0)

--- a/Solo/UI/Widgets/SelectableListWidget.cs
+++ b/Solo/UI/Widgets/SelectableListWidget.cs
@@ -1,0 +1,192 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Collections.Generic;
+
+namespace Solo.UI.Widgets;
+
+public class SelectableListWidget : PanelWidget
+{
+    private static Texture2D? _pixelTexture;
+    private int _hoveredIndex = -1;
+
+    public SelectableListWidget()
+    {
+        ShowCloseButton = false;
+        Scrollable = true;
+        ContentPadding = 0;
+    }
+
+    private List<string> _items = new();
+
+    public List<string> Items
+    {
+        get => _items;
+        set
+        {
+            if (_items != value)
+            {
+                _items = value;
+                InvalidateMeasure();
+            }
+        }
+    }
+    public int SelectedIndex { get; set; } = -1;
+    public int ItemHeight { get; set; } = UITheme.LineHeight + 8;
+    public int ItemPadding { get; set; } = 8;
+    public Color SelectedColor { get; set; } = UITheme.Selection.SelectedBackground;
+    public Color HoverColor { get; set; } = UITheme.Selection.HoverBackground;
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color SelectedTextColor { get; set; } = UITheme.Text.Title;
+
+    public event Action<int>? OnSelectionChanged;
+
+    protected override float ContentHeight => Items.Count * ItemHeight;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return new Vector2(availableWidth, Items.Count * ItemHeight);
+    }
+
+    private static Texture2D GetListPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    public void SelectNext()
+    {
+        if (Items.Count == 0) return;
+        SelectedIndex = (SelectedIndex + 1) % Items.Count;
+        OnSelectionChanged?.Invoke(SelectedIndex);
+        EnsureSelectedVisible();
+    }
+
+    public void SelectPrevious()
+    {
+        if (Items.Count == 0) return;
+        SelectedIndex = SelectedIndex <= 0 ? Items.Count - 1 : SelectedIndex - 1;
+        OnSelectionChanged?.Invoke(SelectedIndex);
+        EnsureSelectedVisible();
+    }
+
+    private void EnsureSelectedVisible()
+    {
+        if (SelectedIndex < 0) return;
+
+        float itemY = SelectedIndex * ItemHeight;
+        float visibleHeight = Size.Y - BorderWidth * 2;
+
+        if (itemY < ScrollOffset)
+            ScrollOffset = itemY;
+        else if (itemY + ItemHeight > ScrollOffset + visibleHeight)
+            ScrollOffset = itemY + ItemHeight - visibleHeight;
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        base.UpdateCore(gameTime, mouseState, previousMouseState);
+
+        _hoveredIndex = -1;
+        var mousePoint = new Point(mouseState.X, mouseState.Y);
+
+        if (Bounds.Contains(mousePoint))
+        {
+            float relativeY = mouseState.Y - ScreenPosition.Y - BorderWidth + ScrollOffset;
+            int index = (int)(relativeY / ItemHeight);
+            if (index >= 0 && index < Items.Count)
+                _hoveredIndex = index;
+        }
+
+        if (mouseState.LeftButton == ButtonState.Pressed &&
+            previousMouseState.LeftButton == ButtonState.Released &&
+            _hoveredIndex >= 0)
+        {
+            SelectedIndex = _hoveredIndex;
+            OnSelectionChanged?.Invoke(SelectedIndex);
+        }
+    }
+
+    public override void Render(SpriteBatch spriteBatch)
+    {
+        if (!Visible)
+            return;
+
+        // Render panel background/border
+        var pixel = GetListPixelTexture(spriteBatch.GraphicsDevice);
+        spriteBatch.Draw(pixel, Bounds, BackgroundColor);
+
+        if (BorderWidth > 0)
+        {
+            var bounds = Bounds;
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, bounds.Width, BorderWidth), BorderColor);
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Bottom - BorderWidth, bounds.Width, BorderWidth), BorderColor);
+            spriteBatch.Draw(pixel, new Rectangle(bounds.X, bounds.Y, BorderWidth, bounds.Height), BorderColor);
+            spriteBatch.Draw(pixel, new Rectangle(bounds.Right - BorderWidth, bounds.Y, BorderWidth, bounds.Height), BorderColor);
+        }
+
+        if (Items.Count == 0)
+            return;
+
+        // End current batch to flush state, then save
+        spriteBatch.End();
+
+        var originalScissor = spriteBatch.GraphicsDevice.ScissorRectangle;
+        var originalRasterizer = spriteBatch.GraphicsDevice.RasterizerState;
+
+        var contentBounds = new Rectangle(
+            Bounds.X + BorderWidth,
+            Bounds.Y + BorderWidth,
+            Bounds.Width - BorderWidth * 2,
+            Bounds.Height - BorderWidth * 2
+        );
+
+        var scale = UITheme.UIScale;
+        var sampler = scale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
+        var matrix = scale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
+        var rasterizerState = new RasterizerState { ScissorTestEnable = true };
+        spriteBatch.GraphicsDevice.ScissorRectangle = new Rectangle(
+            (int)(contentBounds.X * scale),
+            (int)(contentBounds.Y * scale),
+            (int)(contentBounds.Width * scale),
+            (int)(contentBounds.Height * scale)
+        );
+
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, sampler, null, rasterizerState, null, matrix);
+
+        float y = ScreenPosition.Y + BorderWidth - ScrollOffset;
+
+        for (int i = 0; i < Items.Count; i++)
+        {
+            var itemBounds = new Rectangle(
+                (int)ScreenPosition.X + BorderWidth,
+                (int)y,
+                (int)Size.X - BorderWidth * 2,
+                ItemHeight
+            );
+
+            // Draw selection/hover background
+            if (i == SelectedIndex)
+                spriteBatch.Draw(pixel, itemBounds, SelectedColor);
+            else if (i == _hoveredIndex)
+                spriteBatch.Draw(pixel, itemBounds, HoverColor);
+
+            // Draw text
+            var textColor = i == SelectedIndex ? SelectedTextColor : TextColor;
+            var textPos = new Vector2(itemBounds.X + ItemPadding, itemBounds.Y + (ItemHeight - UITheme.Font.LineSpacing) / 2);
+            spriteBatch.DrawString(UITheme.Font, Items[i], textPos, textColor);
+
+            y += ItemHeight;
+        }
+
+        spriteBatch.End();
+
+        spriteBatch.GraphicsDevice.ScissorRectangle = originalScissor;
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, sampler, null, originalRasterizer, null, matrix);
+    }
+}

--- a/Solo/UI/Widgets/SliderWidget.cs
+++ b/Solo/UI/Widgets/SliderWidget.cs
@@ -112,7 +112,7 @@ public class SliderWidget : Widget
 
     protected override void RenderCore(SpriteBatch spriteBatch)
     {
-        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
 
         // Draw track
         float trackY = ScreenPosition.Y + (Size.Y - TrackHeight) / 2f;
@@ -128,17 +128,5 @@ public class SliderWidget : Widget
         var thumbRect = GetThumbRect();
         var thumbColor = _isDragging ? ThumbHoverColor : ThumbColor;
         spriteBatch.Draw(pixel, thumbRect, thumbColor);
-    }
-
-    private static Texture2D? _pixelTexture;
-
-    private static Texture2D GetPixelTexture(GraphicsDevice device)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(device, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
     }
 }

--- a/Solo/UI/Widgets/SliderWidget.cs
+++ b/Solo/UI/Widgets/SliderWidget.cs
@@ -1,0 +1,144 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class SliderWidget : Widget
+{
+    private const int TrackHeight = 6;
+    private const int ThumbWidth = 12;
+    private const int ThumbHeight = 20;
+
+    private bool _isDragging;
+    private int _value;
+
+    public SliderWidget()
+    {
+        Size = new Vector2(200, ThumbHeight);
+    }
+
+    public int MinValue { get; set; } = 0;
+    public int MaxValue { get; set; } = 100;
+
+    public int Value
+    {
+        get => _value;
+        set
+        {
+            var clamped = Math.Clamp(value, MinValue, MaxValue);
+            if (_value != clamped)
+            {
+                _value = clamped;
+                OnValueChanged?.Invoke(_value);
+            }
+        }
+    }
+
+    public Color TrackColor { get; set; } = UITheme.Scrollbar.Track;
+    public Color ThumbColor { get; set; } = UITheme.Scrollbar.Thumb;
+    public Color ThumbHoverColor { get; set; } = UITheme.Selection.SlotHover;
+
+    public event Action<int>? OnValueChanged;
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        var mousePoint = new Point(mouseState.X, mouseState.Y);
+        var thumbRect = GetThumbRect();
+        bool isOverThumb = thumbRect.Contains(mousePoint);
+        bool isOverTrack = Bounds.Contains(mousePoint);
+
+        if (mouseState.LeftButton == ButtonState.Pressed)
+        {
+            if (previousMouseState.LeftButton == ButtonState.Released && (isOverThumb || isOverTrack))
+            {
+                _isDragging = true;
+            }
+
+            if (_isDragging)
+            {
+                UpdateValueFromMouse(mouseState.X);
+            }
+        }
+        else
+        {
+            _isDragging = false;
+        }
+
+        base.UpdateCore(gameTime, mouseState, previousMouseState);
+    }
+
+    private void UpdateValueFromMouse(int mouseX)
+    {
+        float trackStartX = ScreenPosition.X + ThumbWidth / 2f;
+        float trackEndX = ScreenPosition.X + Size.X - ThumbWidth / 2f;
+        float trackWidth = trackEndX - trackStartX;
+
+        if (trackWidth <= 0)
+            return;
+
+        float relativeX = mouseX - trackStartX;
+        float ratio = Math.Clamp(relativeX / trackWidth, 0f, 1f);
+
+        int range = MaxValue - MinValue;
+        Value = MinValue + (int)MathF.Round(ratio * range);
+    }
+
+    private Rectangle GetThumbRect()
+    {
+        float trackStartX = ScreenPosition.X + ThumbWidth / 2f;
+        float trackEndX = ScreenPosition.X + Size.X - ThumbWidth / 2f;
+        float trackWidth = trackEndX - trackStartX;
+
+        int range = MaxValue - MinValue;
+        float ratio = range > 0 ? (float)(_value - MinValue) / range : 0f;
+
+        float thumbCenterX = trackStartX + ratio * trackWidth;
+        float thumbY = ScreenPosition.Y + (Size.Y - ThumbHeight) / 2f;
+
+        return new Rectangle(
+            (int)(thumbCenterX - ThumbWidth / 2f),
+            (int)thumbY,
+            ThumbWidth,
+            ThumbHeight
+        );
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+
+        // Draw track
+        float trackY = ScreenPosition.Y + (Size.Y - TrackHeight) / 2f;
+        var trackRect = new Rectangle(
+            (int)ScreenPosition.X,
+            (int)trackY,
+            (int)Size.X,
+            TrackHeight
+        );
+        spriteBatch.Draw(pixel, trackRect, TrackColor);
+
+        // Draw thumb
+        var thumbRect = GetThumbRect();
+        var thumbColor = _isDragging ? ThumbHoverColor : ThumbColor;
+        spriteBatch.Draw(pixel, thumbRect, thumbColor);
+    }
+
+    private static Texture2D? _pixelTexture;
+
+    private static Texture2D GetPixelTexture(GraphicsDevice device)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(device, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+}

--- a/Solo/UI/Widgets/StatProgressRowWidget.cs
+++ b/Solo/UI/Widgets/StatProgressRowWidget.cs
@@ -1,0 +1,76 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Solo.UI.Widgets;
+
+public class StatProgressRowWidget : Widget
+{
+    private static Texture2D? _pixelTexture;
+    private const int ProgressBarWidth = 100;
+    private const int ProgressBarHeight = 10;
+
+    public StatProgressRowWidget()
+    {
+    }
+
+    public string StatName { get; set; } = string.Empty;
+    public float StatValue { get; set; }
+    public float Progress { get; set; }
+    public Color BarColor { get; set; } = UITheme.StatusBar.ProgressFill;
+    public Color LabelColor { get; set; } = UITheme.Text.Secondary;
+
+    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pos = ScreenPosition;
+
+        // Draw stat name and value
+        string label = $"{StatName}: {StatValue:F0}";
+        spriteBatch.DrawString(UITheme.Font, label, pos, LabelColor);
+
+        // Draw progress bar
+        int barX = (int)(pos.X + Size.X - ProgressBarWidth);
+        int barY = (int)pos.Y + 4;
+
+        // Background
+        spriteBatch.Draw(pixel, new Rectangle(barX, barY, ProgressBarWidth, ProgressBarHeight), UITheme.StatusBar.ProgressBackground);
+
+        // Fill
+        int fillWidth = (int)(ProgressBarWidth * (Progress / 100f));
+        if (fillWidth > 0)
+        {
+            var fillColor = BarColor;
+            spriteBatch.Draw(pixel, new Rectangle(barX, barY, fillWidth, ProgressBarHeight), fillColor);
+        }
+
+        // Border
+        var borderColor = UITheme.Panel.BorderColor;
+        spriteBatch.Draw(pixel, new Rectangle(barX, barY, ProgressBarWidth, 1), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barX, barY + ProgressBarHeight - 1, ProgressBarWidth, 1), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barX, barY, 1, ProgressBarHeight), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barX + ProgressBarWidth - 1, barY, 1, ProgressBarHeight), borderColor);
+
+        // Progress percentage
+        string percentText = $"{Progress:F0}%";
+        var percentSize = UITheme.Font.MeasureString(percentText);
+        float percentX = barX + (ProgressBarWidth - percentSize.X) / 2;
+        // Draw with shadow for readability
+        spriteBatch.DrawString(UITheme.Font, percentText, new Vector2(percentX + 1, pos.Y + 1), UITheme.Text.Shadow * 0.5f);
+        spriteBatch.DrawString(UITheme.Font, percentText, new Vector2(percentX, pos.Y), UITheme.Text.Primary);
+    }
+}

--- a/Solo/UI/Widgets/StatProgressRowWidget.cs
+++ b/Solo/UI/Widgets/StatProgressRowWidget.cs
@@ -5,7 +5,6 @@ namespace Solo.UI.Widgets;
 
 public class StatProgressRowWidget : Widget
 {
-    private static Texture2D? _pixelTexture;
     private const int ProgressBarWidth = 100;
     private const int ProgressBarHeight = 10;
 
@@ -19,16 +18,6 @@ public class StatProgressRowWidget : Widget
     public Color BarColor { get; set; } = UITheme.StatusBar.ProgressFill;
     public Color LabelColor { get; set; } = UITheme.Text.Secondary;
 
-    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
-    }
-
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
         return Size;
@@ -36,7 +25,7 @@ public class StatProgressRowWidget : Widget
 
     protected override void RenderCore(SpriteBatch spriteBatch)
     {
-        var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var pos = ScreenPosition;
 
         // Draw stat name and value

--- a/Solo/UI/Widgets/StepIndicatorWidget.cs
+++ b/Solo/UI/Widgets/StepIndicatorWidget.cs
@@ -7,8 +7,6 @@ namespace Solo.UI.Widgets;
 
 public class StepIndicatorWidget : Widget
 {
-    private static Texture2D? _pixelTexture;
-
     public StepIndicatorWidget()
     {
     }
@@ -22,16 +20,6 @@ public class StepIndicatorWidget : Widget
     public Color SeparatorColor { get; set; } = UITheme.Text.Placeholder;
 
     public event Action<int>? OnStepClicked;
-
-    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
-    }
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
@@ -76,7 +64,7 @@ public class StepIndicatorWidget : Widget
             {
                 var dotX = startX + separatorWidth / 2 - 2;
                 var dotY = y + UITheme.Font.LineSpacing / 2 - 2;
-                var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+                var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
                 spriteBatch.Draw(pixel, new Rectangle((int)dotX, (int)dotY, 4, 4), SeparatorColor);
                 startX += separatorWidth;
             }

--- a/Solo/UI/Widgets/StepIndicatorWidget.cs
+++ b/Solo/UI/Widgets/StepIndicatorWidget.cs
@@ -1,0 +1,118 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+
+namespace Solo.UI.Widgets;
+
+public class StepIndicatorWidget : Widget
+{
+    private static Texture2D? _pixelTexture;
+
+    public StepIndicatorWidget()
+    {
+    }
+
+    public List<string> Steps { get; set; } = new();
+    public int CurrentStep { get; set; }
+    public HashSet<int> CompletedSteps { get; set; } = new();
+    public Color ActiveColor { get; set; } = UITheme.Text.Highlight;
+    public Color CompletedColor { get; set; } = UITheme.Text.SectionHeader;
+    public Color InactiveColor { get; set; } = UITheme.Text.Muted;
+    public Color SeparatorColor { get; set; } = UITheme.Text.Placeholder;
+
+    public event Action<int>? OnStepClicked;
+
+    private static Texture2D GetPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return new Vector2(availableWidth, UITheme.LineHeight + 8);
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        if (Steps.Count == 0)
+            return;
+
+        float totalWidth = 0;
+        var stepWidths = new List<float>();
+
+        foreach (var step in Steps)
+        {
+            var width = UITheme.Font.MeasureString(step).X;
+            stepWidths.Add(width);
+            totalWidth += width;
+        }
+
+        float separatorWidth = 30;
+        totalWidth += (Steps.Count - 1) * separatorWidth;
+
+        float startX = ScreenPosition.X + (Size.X - totalWidth) / 2;
+        float y = ScreenPosition.Y + (Size.Y - UITheme.Font.LineSpacing) / 2;
+
+        for (int i = 0; i < Steps.Count; i++)
+        {
+            Color color;
+            if (i == CurrentStep)
+                color = ActiveColor;
+            else if (CompletedSteps.Contains(i))
+                color = CompletedColor;
+            else
+                color = InactiveColor;
+
+            spriteBatch.DrawString(UITheme.Font, Steps[i], new Vector2(startX, y), color);
+            startX += stepWidths[i];
+
+            if (i < Steps.Count - 1)
+            {
+                var dotX = startX + separatorWidth / 2 - 2;
+                var dotY = y + UITheme.Font.LineSpacing / 2 - 2;
+                var pixel = GetPixelTexture(spriteBatch.GraphicsDevice);
+                spriteBatch.Draw(pixel, new Rectangle((int)dotX, (int)dotY, 4, 4), SeparatorColor);
+                startX += separatorWidth;
+            }
+        }
+    }
+
+    protected override void OnMouseClick(Point mousePosition)
+    {
+        if (Steps.Count == 0)
+            return;
+
+        float totalWidth = 0;
+        var stepWidths = new List<float>();
+
+        foreach (var step in Steps)
+        {
+            var width = UITheme.Font.MeasureString(step).X;
+            stepWidths.Add(width);
+            totalWidth += width;
+        }
+
+        float separatorWidth = 30;
+        totalWidth += (Steps.Count - 1) * separatorWidth;
+
+        float startX = ScreenPosition.X + (Size.X - totalWidth) / 2;
+        float y = ScreenPosition.Y;
+
+        for (int i = 0; i < Steps.Count; i++)
+        {
+            var stepBounds = new Rectangle((int)startX, (int)y, (int)stepWidths[i], (int)Size.Y);
+            if (stepBounds.Contains(mousePosition) && CompletedSteps.Contains(i))
+            {
+                OnStepClicked?.Invoke(i);
+                return;
+            }
+            startX += stepWidths[i] + separatorWidth;
+        }
+    }
+}

--- a/Solo/UI/Widgets/TextInputWidget.cs
+++ b/Solo/UI/Widgets/TextInputWidget.cs
@@ -7,7 +7,6 @@ namespace Solo.UI.Widgets;
 
 public class TextInputWidget : PanelWidget
 {
-    private static Texture2D? _pixelTexture;
     private double _cursorBlinkTimer;
     private bool _cursorVisible = true;
     private const double CursorBlinkRate = 0.5;
@@ -32,16 +31,6 @@ public class TextInputWidget : PanelWidget
     public int Padding { get; set; } = 8;
 
     public event Action<string>? OnTextChanged;
-
-    private static Texture2D GetInputPixelTexture(GraphicsDevice graphicsDevice)
-    {
-        if (_pixelTexture == null)
-        {
-            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
-            _pixelTexture.SetData(new[] { Color.White });
-        }
-        return _pixelTexture;
-    }
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
@@ -137,7 +126,7 @@ public class TextInputWidget : PanelWidget
     {
         base.RenderCore(spriteBatch);
 
-        var pixel = GetInputPixelTexture(spriteBatch.GraphicsDevice);
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var textY = ScreenPosition.Y + (Size.Y - UITheme.Font.LineSpacing) / 2;
         var textX = ScreenPosition.X + Padding;
 

--- a/Solo/UI/Widgets/TextInputWidget.cs
+++ b/Solo/UI/Widgets/TextInputWidget.cs
@@ -1,0 +1,163 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System;
+
+namespace Solo.UI.Widgets;
+
+public class TextInputWidget : PanelWidget
+{
+    private static Texture2D? _pixelTexture;
+    private double _cursorBlinkTimer;
+    private bool _cursorVisible = true;
+    private const double CursorBlinkRate = 0.5;
+    private KeyboardState _previousKeyboardState;
+
+    public TextInputWidget()
+    {
+        ShowCloseButton = false;
+        ContentPadding = 0;
+        BackgroundColor = UITheme.Input.BackgroundColor;
+        BorderColor = UITheme.Input.BorderColor;
+        BorderWidth = UITheme.Input.BorderWidth;
+    }
+
+    public string Text { get; set; } = string.Empty;
+    public int MaxLength { get; set; } = 20;
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+    public Color PlaceholderColor { get; set; } = UITheme.Text.Placeholder;
+    public Color CursorColor { get; set; } = UITheme.Text.Highlight;
+    public string PlaceholderText { get; set; } = "Enter name...";
+    public bool IsFocused { get; set; } = true;
+    public int Padding { get; set; } = 8;
+
+    public event Action<string>? OnTextChanged;
+
+    private static Texture2D GetInputPixelTexture(GraphicsDevice graphicsDevice)
+    {
+        if (_pixelTexture == null)
+        {
+            _pixelTexture = new Texture2D(graphicsDevice, 1, 1);
+            _pixelTexture.SetData(new[] { Color.White });
+        }
+        return _pixelTexture;
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        base.UpdateCore(gameTime, mouseState, previousMouseState);
+
+        if (!IsFocused)
+            return;
+
+        // Cursor blink
+        _cursorBlinkTimer += gameTime.ElapsedGameTime.TotalSeconds;
+        if (_cursorBlinkTimer >= CursorBlinkRate)
+        {
+            _cursorBlinkTimer = 0;
+            _cursorVisible = !_cursorVisible;
+        }
+
+        // Handle keyboard input
+        var keyboardState = Keyboard.GetState();
+        var pressedKeys = keyboardState.GetPressedKeys();
+
+        foreach (var key in pressedKeys)
+        {
+            if (!_previousKeyboardState.IsKeyDown(key))
+            {
+                HandleKeyPress(key, keyboardState);
+            }
+        }
+
+        _previousKeyboardState = keyboardState;
+    }
+
+    private void HandleKeyPress(Keys key, KeyboardState keyboardState)
+    {
+        bool shift = keyboardState.IsKeyDown(Keys.LeftShift) || keyboardState.IsKeyDown(Keys.RightShift);
+
+        if (key == Keys.Back && Text.Length > 0)
+        {
+            Text = Text[..^1];
+            OnTextChanged?.Invoke(Text);
+            _cursorVisible = true;
+            _cursorBlinkTimer = 0;
+        }
+        else if (key == Keys.Delete)
+        {
+            Text = string.Empty;
+            OnTextChanged?.Invoke(Text);
+        }
+        else if (Text.Length < MaxLength)
+        {
+            char? c = KeyToChar(key, shift);
+            if (c.HasValue)
+            {
+                Text += c.Value;
+                OnTextChanged?.Invoke(Text);
+                _cursorVisible = true;
+                _cursorBlinkTimer = 0;
+            }
+        }
+    }
+
+    private static char? KeyToChar(Keys key, bool shift)
+    {
+        // Letters
+        if (key >= Keys.A && key <= Keys.Z)
+        {
+            char c = (char)('a' + (key - Keys.A));
+            return shift ? char.ToUpper(c) : c;
+        }
+
+        // Numbers
+        if (key >= Keys.D0 && key <= Keys.D9 && !shift)
+            return (char)('0' + (key - Keys.D0));
+
+        // Space
+        if (key == Keys.Space)
+            return ' ';
+
+        // Common punctuation
+        if (key == Keys.OemMinus)
+            return shift ? '_' : '-';
+        if (key == Keys.OemPeriod)
+            return '.';
+
+        return null;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        base.RenderCore(spriteBatch);
+
+        var pixel = GetInputPixelTexture(spriteBatch.GraphicsDevice);
+        var textY = ScreenPosition.Y + (Size.Y - UITheme.Font.LineSpacing) / 2;
+        var textX = ScreenPosition.X + Padding;
+
+        if (string.IsNullOrEmpty(Text))
+        {
+            // Draw placeholder
+            spriteBatch.DrawString(UITheme.Font, PlaceholderText, new Vector2(textX, textY), PlaceholderColor);
+        }
+        else
+        {
+            // Draw text
+            spriteBatch.DrawString(UITheme.Font, Text, new Vector2(textX, textY), TextColor);
+        }
+
+        // Draw cursor
+        if (IsFocused && _cursorVisible)
+        {
+            var textWidth = string.IsNullOrEmpty(Text) ? 0 : UITheme.Font.MeasureString(Text).X;
+            var cursorX = textX + textWidth + 2;
+            spriteBatch.Draw(pixel, new Rectangle((int)cursorX, (int)textY, 2, UITheme.Font.LineSpacing), CursorColor);
+        }
+    }
+}

--- a/Solo/UI/Widgets/TooltipWidget.cs
+++ b/Solo/UI/Widgets/TooltipWidget.cs
@@ -1,0 +1,284 @@
+using Solo.UI.Tooltips;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+
+namespace Solo.UI.Widgets;
+
+public class TooltipWidget : PanelWidget
+{
+    private const int Padding = 8;
+    private const int ColumnGap = 16;
+    private const int RowGap = 2;
+
+    private TooltipContent? _content;
+    private TooltipTableData? _tableData;
+
+    public TooltipWidget()
+    {
+        ShowCloseButton = false;
+        BackgroundColor = UITheme.Tooltip.BackgroundColor;
+        BorderColor = UITheme.Tooltip.BorderColor;
+        BorderWidth = UITheme.Tooltip.BorderWidth;
+        Visible = false;
+    }
+
+    public string Text { get; set; } = string.Empty;
+    public Color TextColor { get; set; } = UITheme.Text.Primary;
+
+    public void SetContent(TooltipContent content)
+    {
+        _content = content;
+        _tableData = null;
+        Text = string.Empty;
+        UpdateSize();
+    }
+
+    public void SetTableContent(TooltipTableData table)
+    {
+        _tableData = table;
+        _content = null;
+        Text = string.Empty;
+        UpdateSize();
+    }
+
+    public void SetText(string text)
+    {
+        Text = text;
+        _content = null;
+        _tableData = null;
+        UpdateSize();
+    }
+
+    public void UpdateSize()
+    {
+        InvalidateMeasure();
+        var desired = Measure(float.MaxValue, float.MaxValue);
+        Arrange(desired);
+    }
+
+    protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        if (_tableData != null)
+            return CalculateTableSize();
+
+        if (_content != null && _content.Lines.Count > 0)
+            return CalculateContentSize();
+
+        if (!string.IsNullOrEmpty(Text))
+        {
+            var textSize = UITheme.TooltipFont.MeasureString(Text);
+            return new Vector2(textSize.X + Padding * 2, textSize.Y + Padding * 2);
+        }
+
+        return Vector2.Zero;
+    }
+
+    private Vector2 CalculateContentSize()
+    {
+        if (_content == null)
+            return Vector2.Zero;
+
+        float maxWidth = 0;
+        float totalHeight = 0;
+        float lineHeight = UITheme.TooltipFont.LineSpacing;
+
+        foreach (var line in _content.Lines)
+        {
+            if (!string.IsNullOrEmpty(line.Text))
+            {
+                var lineSize = UITheme.TooltipFont.MeasureString(line.Text);
+                if (lineSize.X > maxWidth)
+                    maxWidth = lineSize.X;
+            }
+            totalHeight += lineHeight;
+        }
+
+        return new Vector2(maxWidth + Padding * 2, totalHeight + Padding * 2);
+    }
+
+    private Vector2 CalculateTableSize()
+    {
+        if (_tableData == null)
+            return Vector2.Zero;
+
+        var columnWidths = CalculateColumnWidths();
+        float totalWidth = Padding * 2;
+        for (int i = 0; i < columnWidths.Length; i++)
+        {
+            totalWidth += columnWidths[i];
+            if (i < columnWidths.Length - 1)
+                totalWidth += ColumnGap;
+        }
+
+        float lineHeight = UITheme.TooltipFont.LineSpacing + RowGap;
+        int headerRows = HasSlotLabels() ? 2 : 1;
+        int totalRows = headerRows + _tableData.Rows.Count;
+        float totalHeight = Padding * 2 + totalRows * lineHeight;
+
+        return new Vector2(totalWidth, totalHeight);
+    }
+
+    private float[] CalculateColumnWidths()
+    {
+        if (_tableData == null)
+            return [];
+
+        int columnCount = _tableData.Headers.Count + 1;
+        var widths = new float[columnCount];
+
+        float statColumnWidth = 0;
+        foreach (var row in _tableData.Rows)
+        {
+            var width = UITheme.TooltipFont.MeasureString(row.StatName).X;
+            if (width > statColumnWidth)
+                statColumnWidth = width;
+        }
+        widths[0] = statColumnWidth;
+
+        for (int i = 0; i < _tableData.Headers.Count; i++)
+        {
+            var header = _tableData.Headers[i];
+            float maxWidth = UITheme.TooltipFont.MeasureString(header.ItemName).X;
+
+            if (!string.IsNullOrEmpty(header.SlotLabel))
+            {
+                var labelWidth = UITheme.TooltipFont.MeasureString(header.SlotLabel).X;
+                if (labelWidth > maxWidth)
+                    maxWidth = labelWidth;
+            }
+
+            foreach (var row in _tableData.Rows)
+            {
+                if (i < row.Cells.Count)
+                {
+                    var cellWidth = UITheme.TooltipFont.MeasureString(row.Cells[i].Value).X;
+                    if (cellWidth > maxWidth)
+                        maxWidth = cellWidth;
+                }
+            }
+
+            widths[i + 1] = maxWidth;
+        }
+
+        return widths;
+    }
+
+    private bool HasSlotLabels()
+    {
+        if (_tableData == null)
+            return false;
+
+        foreach (var header in _tableData.Headers)
+        {
+            if (!string.IsNullOrEmpty(header.SlotLabel))
+                return true;
+        }
+        return false;
+    }
+
+    protected override void RenderCore(SpriteBatch spriteBatch)
+    {
+        bool hasContent = _tableData != null ||
+                          (_content != null && _content.Lines.Count > 0) ||
+                          !string.IsNullOrEmpty(Text);
+        if (!hasContent)
+            return;
+
+        base.RenderCore(spriteBatch);
+
+        if (_tableData != null)
+        {
+            RenderTable(spriteBatch);
+        }
+        else if (_content != null && _content.Lines.Count > 0)
+        {
+            RenderColoredContent(spriteBatch);
+        }
+        else if (!string.IsNullOrEmpty(Text))
+        {
+            var textPos = ScreenPosition + new Vector2(Padding, Padding);
+            spriteBatch.DrawString(UITheme.TooltipFont, Text, textPos, TextColor);
+        }
+    }
+
+    private void RenderColoredContent(SpriteBatch spriteBatch)
+    {
+        if (_content == null)
+            return;
+
+        var pos = ScreenPosition + new Vector2(Padding, Padding);
+        float lineHeight = UITheme.TooltipFont.LineSpacing;
+
+        foreach (var line in _content.Lines)
+        {
+            if (!string.IsNullOrEmpty(line.Text))
+            {
+                spriteBatch.DrawString(UITheme.TooltipFont, line.Text, pos, line.Color);
+            }
+            pos.Y += lineHeight;
+        }
+    }
+
+    private void RenderTable(SpriteBatch spriteBatch)
+    {
+        if (_tableData == null)
+            return;
+
+        var columnWidths = CalculateColumnWidths();
+        float lineHeight = UITheme.TooltipFont.LineSpacing + RowGap;
+        var basePos = ScreenPosition + new Vector2(Padding, Padding);
+
+        float[] columnX = new float[columnWidths.Length];
+        columnX[0] = basePos.X;
+        for (int i = 1; i < columnWidths.Length; i++)
+        {
+            columnX[i] = columnX[i - 1] + columnWidths[i - 1] + ColumnGap;
+        }
+
+        float y = basePos.Y;
+
+        for (int i = 0; i < _tableData.Headers.Count; i++)
+        {
+            var header = _tableData.Headers[i];
+            var x = columnX[i + 1];
+            var nameWidth = UITheme.TooltipFont.MeasureString(header.ItemName).X;
+            var centeredX = x + (columnWidths[i + 1] - nameWidth) / 2;
+            spriteBatch.DrawString(UITheme.TooltipFont, header.ItemName, new Vector2(centeredX, y), UITheme.Text.Title);
+        }
+        y += lineHeight;
+
+        if (HasSlotLabels())
+        {
+            for (int i = 0; i < _tableData.Headers.Count; i++)
+            {
+                var header = _tableData.Headers[i];
+                if (!string.IsNullOrEmpty(header.SlotLabel))
+                {
+                    var x = columnX[i + 1];
+                    var labelWidth = UITheme.TooltipFont.MeasureString(header.SlotLabel).X;
+                    var centeredX = x + (columnWidths[i + 1] - labelWidth) / 2;
+                    spriteBatch.DrawString(UITheme.TooltipFont, header.SlotLabel, new Vector2(centeredX, y), UITheme.Text.Muted);
+                }
+            }
+            y += lineHeight;
+        }
+
+        foreach (var row in _tableData.Rows)
+        {
+            spriteBatch.DrawString(UITheme.TooltipFont, row.StatName, new Vector2(columnX[0], y), UITheme.Text.Secondary);
+
+            for (int i = 0; i < row.Cells.Count && i < _tableData.Headers.Count; i++)
+            {
+                var cell = row.Cells[i];
+                var x = columnX[i + 1];
+                var cellWidth = UITheme.TooltipFont.MeasureString(cell.Value).X;
+                var centeredX = x + (columnWidths[i + 1] - cellWidth) / 2;
+                spriteBatch.DrawString(UITheme.TooltipFont, cell.Value, new Vector2(centeredX, y), cell.Color);
+            }
+
+            y += lineHeight;
+        }
+    }
+}

--- a/Solo/UI/Widgets/Widget.cs
+++ b/Solo/UI/Widgets/Widget.cs
@@ -1,0 +1,215 @@
+using Solo.UI.Tooltips;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using System.Collections.Generic;
+
+namespace Solo.UI.Widgets;
+
+public abstract class Widget
+{
+    private readonly List<Widget> _children = new();
+    private Vector2 _position;
+    private Vector2 _size;
+    private Vector2 _desiredSize;
+    private bool _isMeasureDirty = true;
+    private float _lastMeasureWidth;
+    private float _lastMeasureHeight;
+
+    protected Widget()
+    {
+        Visible = true;
+        Enabled = true;
+    }
+
+    public Vector2 Position
+    {
+        get => _position;
+        set => _position = value;
+    }
+
+    public Vector2 Size
+    {
+        get => _size;
+        set => _size = value;
+    }
+
+    public bool Visible { get; set; }
+    public bool Enabled { get; set; }
+    public Widget? Parent { get; private set; }
+    public IReadOnlyList<Widget> Children => _children;
+    public Vector2 DesiredSize => _desiredSize;
+
+    public Vector2 ScreenPosition
+    {
+        get
+        {
+            if (Parent == null)
+                return Position;
+            return Parent.ScreenPosition + Parent.ChildRenderOffset + Position;
+        }
+    }
+
+    /// <summary>
+    /// Offset applied to children's positions (used for scrolling).
+    /// </summary>
+    protected virtual Vector2 ChildRenderOffset => Vector2.Zero;
+
+    public Rectangle Bounds => new(
+        (int)ScreenPosition.X,
+        (int)ScreenPosition.Y,
+        (int)Size.X,
+        (int)Size.Y
+    );
+
+    public void AddChild(Widget child)
+    {
+        if (child.Parent != null)
+            child.Parent.RemoveChild(child);
+
+        child.Parent = this;
+        _children.Add(child);
+        InvalidateMeasure();
+    }
+
+    public void RemoveChild(Widget child)
+    {
+        if (_children.Remove(child))
+        {
+            child.Parent = null;
+            InvalidateMeasure();
+        }
+    }
+
+    public void ClearChildren()
+    {
+        foreach (var child in _children)
+            child.Parent = null;
+        _children.Clear();
+        InvalidateMeasure();
+    }
+
+    public Vector2 Measure(float availableWidth, float availableHeight)
+    {
+        bool constraintsChanged = availableWidth != _lastMeasureWidth || availableHeight != _lastMeasureHeight;
+        if (!_isMeasureDirty && !constraintsChanged)
+            return _desiredSize;
+
+        _lastMeasureWidth = availableWidth;
+        _lastMeasureHeight = availableHeight;
+        _desiredSize = MeasureCore(availableWidth, availableHeight);
+        _isMeasureDirty = false;
+        return _desiredSize;
+    }
+
+    protected virtual Vector2 MeasureCore(float availableWidth, float availableHeight)
+    {
+        return Size;
+    }
+
+    public void Arrange(Vector2 finalSize)
+    {
+        var oldSize = Size;
+        Size = finalSize;
+        ArrangeCore(finalSize);
+        if (oldSize != Size)
+            OnSizeChanged();
+    }
+
+    protected virtual void ArrangeCore(Vector2 finalSize)
+    {
+    }
+
+    protected virtual void OnSizeChanged()
+    {
+    }
+
+    public void InvalidateMeasure()
+    {
+        if (_isMeasureDirty)
+            return;
+        _isMeasureDirty = true;
+        Parent?.InvalidateMeasure();
+    }
+
+    public void Update(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+        if (!Visible || !Enabled)
+            return;
+
+        if (_isMeasureDirty && Parent == null)
+        {
+            var prevSize = Size;
+            Measure(Size.X, Size.Y);
+            Arrange(DesiredSize);
+
+            if (prevSize != Size)
+            {
+                _isMeasureDirty = true;
+                Measure(Size.X, Size.Y);
+                Arrange(DesiredSize);
+            }
+        }
+
+        UpdateCore(gameTime, mouseState, previousMouseState);
+
+        foreach (var child in _children)
+            child.Update(gameTime, mouseState, previousMouseState);
+    }
+
+    protected virtual void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
+    {
+    }
+
+    public virtual void Render(SpriteBatch spriteBatch)
+    {
+        if (!Visible)
+            return;
+
+        RenderCore(spriteBatch);
+
+        foreach (var child in _children)
+            child.Render(spriteBatch);
+    }
+
+    protected virtual void RenderCore(SpriteBatch spriteBatch)
+    {
+    }
+
+    public bool HandleMouseClick(Point mousePosition)
+    {
+        if (!Visible || !Enabled)
+            return false;
+
+        // Check children first (in reverse order for proper z-ordering)
+        for (int i = _children.Count - 1; i >= 0; i--)
+        {
+            if (_children[i].HandleMouseClick(mousePosition))
+                return true;
+        }
+
+        // Then check self
+        if (Bounds.Contains(mousePosition))
+        {
+            OnMouseClick(mousePosition);
+            return true;
+        }
+
+        return false;
+    }
+
+    protected virtual void OnMouseClick(Point mousePosition)
+    {
+    }
+
+    public bool ContainsPoint(Point point)
+    {
+        return Bounds.Contains(point);
+    }
+
+    public virtual string? GetTooltipText() => null;
+
+    public virtual TooltipContent? GetTooltipContent() => null;
+
+    public virtual TooltipTableData? GetTooltipTableData() => null;
+}


### PR DESCRIPTION
## Summary

- Add a generic UI widget framework to the Solo engine, extracted from ChainwatchDescent
- 21 new files under `Solo/UI/` with namespaces `Solo.UI`, `Solo.UI.Widgets`, `Solo.UI.Tooltips`
- JSON-driven UITheme with scaling, fonts, panel styles, and generic `GetColor(key)`/`GetFloat(key)` accessors for game-specific extensibility
- UIService for widget management, input routing, and tooltip display
- 17 reusable widgets: Widget, PanelWidget, LabelWidget, ButtonWidget, ImageWidget, ProgressBarWidget, SelectableListWidget, CheckboxWidget, TextInputWidget, SliderWidget, TooltipWidget, MetricRowWidget, PointDistributorWidget, StepIndicatorWidget, StatProgressRowWidget, MenuItemWidget, BreadcrumbWidget

## Test plan

- [ ] Build Solo engine (`dotnet build Solo/Solo/Solo.csproj`)
- [ ] Build ChainwatchDescent against updated Solo (companion PR: mizrael/ChainwatchDescent#TBD)
- [ ] Verify UI renders correctly in-game
- [ ] Verify drag-drop works in character panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)