### PR TITLE
Add IsPointOverWidget to UIService

### DIFF
--- a/Solo/UI/UIService.cs
+++ b/Solo/UI/UIService.cs
@@ -229,6 +229,17 @@ public class UIService : IGameService, IRenderable
         return null;
     }
 
+    public bool IsPointOverWidget(Point point)
+    {
+        for (int i = _rootWidgets.Count - 1; i >= 0; i--)
+        {
+            var widget = _rootWidgets[i];
+            if (widget.Visible && widget.ContainsPoint(point))
+                return true;
+        }
+        return false;
+    }
+
     public bool HasVisibleWidgets()
     {
         foreach (var widget in _rootWidgets)


### PR DESCRIPTION
## Summary
- Adds `IsPointOverWidget(Point)` method to `UIService` for click-through prevention
- Enables game-level services to check if a screen point overlaps any visible UI widget before processing input

Related: mizrael/HexMapRenderer#3

## Test plan
- [ ] Build passes (`dotnet build`)
- [ ] Manual testing