### PR TITLE
Fix scrollable panel interaction clipping

### DIFF
--- a/Solo/UI/UIService.cs
+++ b/Solo/UI/UIService.cs
@@ -171,7 +171,7 @@ public class UIService : IGameService, IRenderable
 
     private static TooltipTableData? FindTooltipTableData(Widget widget, Point mousePoint)
     {
-        if (!widget.Visible)
+        if (!widget.Visible || widget.IsInteractionClipped(mousePoint))
             return null;
 
         for (int i = widget.Children.Count - 1; i >= 0; i--)
@@ -191,7 +191,7 @@ public class UIService : IGameService, IRenderable
 
     private static TooltipContent? FindTooltipContent(Widget widget, Point mousePoint)
     {
-        if (!widget.Visible)
+        if (!widget.Visible || widget.IsInteractionClipped(mousePoint))
             return null;
 
         for (int i = widget.Children.Count - 1; i >= 0; i--)
@@ -211,7 +211,7 @@ public class UIService : IGameService, IRenderable
 
     private static string? FindTooltipText(Widget widget, Point mousePoint)
     {
-        if (!widget.Visible)
+        if (!widget.Visible || widget.IsInteractionClipped(mousePoint))
             return null;
 
         for (int i = widget.Children.Count - 1; i >= 0; i--)

--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -44,6 +44,9 @@ public class PanelWidget : Widget
         }
     }
 
+    protected override Rectangle? ChildInteractionClipBounds =>
+        Scrollable ? ContentBounds : null;
+
     protected Rectangle CloseButtonBounds
     {
         get

--- a/Solo/UI/Widgets/Widget.cs
+++ b/Solo/UI/Widgets/Widget.cs
@@ -55,6 +55,25 @@ public abstract class Widget
     /// </summary>
     protected virtual Vector2 ChildRenderOffset => Vector2.Zero;
 
+    /// <summary>
+    /// When set, constrains children's mouse interaction to this rectangle.
+    /// Used by scrollable panels to prevent clipped children from receiving events.
+    /// </summary>
+    protected virtual Rectangle? ChildInteractionClipBounds => null;
+
+    /// <summary>
+    /// Returns true if this widget's interaction area is clipped by an ancestor's clip bounds.
+    /// </summary>
+    public bool IsInteractionClipped(Point point)
+    {
+        if (Parent == null)
+            return false;
+        var clip = Parent.ChildInteractionClipBounds;
+        if (clip.HasValue && !clip.Value.Contains(point))
+            return true;
+        return Parent.IsInteractionClipped(point);
+    }
+
     public Rectangle Bounds => new(
         (int)ScreenPosition.X,
         (int)ScreenPosition.Y,
@@ -187,14 +206,15 @@ public abstract class Widget
         if (!Visible || !Enabled)
             return false;
 
-        // Check children first (in reverse order for proper z-ordering)
+        if (IsInteractionClipped(mousePosition))
+            return false;
+
         for (int i = _children.Count - 1; i >= 0; i--)
         {
             if (_children[i].HandleMouseClick(mousePosition))
                 return true;
         }
 
-        // Then check self
         if (Bounds.Contains(mousePosition))
         {
             OnMouseClick(mousePosition);

--- a/Solo/UI/Widgets/Widget.cs
+++ b/Solo/UI/Widgets/Widget.cs
@@ -62,7 +62,8 @@ public abstract class Widget
     protected virtual Rectangle? ChildInteractionClipBounds => null;
 
     /// <summary>
-    /// Returns true if this widget's interaction area is clipped by an ancestor's clip bounds.
+    /// Returns true if the given point falls outside an ancestor's clip bounds,
+    /// meaning this widget should not respond to mouse interaction at that point.
     /// </summary>
     public bool IsInteractionClipped(Point point)
     {


### PR DESCRIPTION
## Summary
- Scrollable panels clipped rendering (scissor rect) but mouse hit-testing, tooltips, and click handling had no awareness of clip bounds
- Children scrolled outside the viewport could still trigger hover, clicks, and tooltips
- Added `ChildInteractionClipBounds` virtual property to Widget, overridden in PanelWidget when Scrollable is true

## Test plan
- [x] Build passes (`dotnet build`)
- [ ] Manual testing: scroll items in a panel, verify clipped items no longer trigger tooltips or clicks