### PR TITLE
feat(ui): support leading icon on tooltip lines

### DIFF
--- a/Solo/UI/Tooltips/TooltipContent.cs
+++ b/Solo/UI/Tooltips/TooltipContent.cs
@@ -1,9 +1,24 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 namespace Solo.UI.Tooltips;
 
-public record TooltipLine(string Text, Color Color);
+public record TooltipLine(string Text, Color Color)
+{
+    /// <summary>
+    /// Optional icon rendered inline before <see cref="Text"/>. Sized to the
+    /// tooltip line height (square box). When set, a small gap separates it
+    /// from the text.
+    /// </summary>
+    public Texture2D? LeadingIcon { get; init; }
+
+    /// <summary>
+    /// Source rectangle within <see cref="LeadingIcon"/>. If null, the full
+    /// texture is used.
+    /// </summary>
+    public Rectangle? LeadingIconSource { get; init; }
+}
 
 public class TooltipContent
 {
@@ -20,6 +35,16 @@ public class TooltipContent
     public TooltipContent AddLine(string text)
     {
         _lines.Add(new TooltipLine(text, UITheme.Text.Primary));
+        return this;
+    }
+
+    public TooltipContent AddIconLine(Texture2D icon, Rectangle? iconSource, string text, Color color)
+    {
+        _lines.Add(new TooltipLine(text, color)
+        {
+            LeadingIcon = icon,
+            LeadingIconSource = iconSource
+        });
         return this;
     }
 

--- a/Solo/UI/Tooltips/TooltipContent.cs
+++ b/Solo/UI/Tooltips/TooltipContent.cs
@@ -7,9 +7,9 @@ namespace Solo.UI.Tooltips;
 public record TooltipLine(string Text, Color Color)
 {
     /// <summary>
-    /// Optional icon rendered inline before <see cref="Text"/>. Sized to the
-    /// tooltip line height (square box). When set, a small gap separates it
-    /// from the text.
+    /// Optional icon rendered inline before <see cref="Text"/>. Scaled to the
+    /// tooltip line height while preserving the source aspect ratio. When set,
+    /// a small gap separates it from the text.
     /// </summary>
     public Texture2D? LeadingIcon { get; init; }
 

--- a/Solo/UI/Widgets/TooltipWidget.cs
+++ b/Solo/UI/Widgets/TooltipWidget.cs
@@ -10,6 +10,7 @@ public class TooltipWidget : PanelWidget
     private const int Padding = 8;
     private const int ColumnGap = 16;
     private const int RowGap = 2;
+    private const int IconTextGap = 4;
 
     private IReadOnlyList<TooltipBlock>? _blocks;
 
@@ -96,16 +97,27 @@ public class TooltipWidget : PanelWidget
 
         foreach (var line in content.Lines)
         {
+            float lineWidth = 0;
+            if (line.LeadingIcon != null)
+                lineWidth += MeasureLineIconWidth(line, lineHeight) + IconTextGap;
             if (!string.IsNullOrEmpty(line.Text))
-            {
-                var lineSize = UITheme.TooltipFont.MeasureString(line.Text);
-                if (lineSize.X > maxWidth)
-                    maxWidth = lineSize.X;
-            }
+                lineWidth += UITheme.TooltipFont.MeasureString(line.Text).X;
+            if (lineWidth > maxWidth)
+                maxWidth = lineWidth;
             totalHeight += lineHeight;
         }
 
         return new Vector2(maxWidth, totalHeight);
+    }
+
+    private static float MeasureLineIconWidth(TooltipLine line, float lineHeight)
+    {
+        if (line.LeadingIcon == null)
+            return 0;
+        var src = line.LeadingIconSource ?? new Rectangle(0, 0, line.LeadingIcon.Width, line.LeadingIcon.Height);
+        if (src.Height <= 0)
+            return lineHeight;
+        return lineHeight * (src.Width / (float)src.Height);
     }
 
     private static Vector2 MeasureTableBlock(TooltipTableBlock table)
@@ -225,9 +237,19 @@ public class TooltipWidget : PanelWidget
 
         foreach (var line in content.Lines)
         {
+            float textOffset = 0;
+
+            if (line.LeadingIcon != null)
+            {
+                float iconWidth = MeasureLineIconWidth(line, lineHeight);
+                var iconRect = new Rectangle((int)pos.X, (int)pos.Y, (int)iconWidth, (int)lineHeight);
+                spriteBatch.Draw(line.LeadingIcon, iconRect, line.LeadingIconSource, Color.White);
+                textOffset = iconWidth + IconTextGap;
+            }
+
             if (!string.IsNullOrEmpty(line.Text))
             {
-                spriteBatch.DrawString(UITheme.TooltipFont, line.Text, pos, line.Color);
+                spriteBatch.DrawString(UITheme.TooltipFont, line.Text, pos + new Vector2(textOffset, 0), line.Color);
             }
             pos.Y += lineHeight;
         }

--- a/Solo/UI/Widgets/TooltipWidget.cs
+++ b/Solo/UI/Widgets/TooltipWidget.cs
@@ -98,9 +98,14 @@ public class TooltipWidget : PanelWidget
         foreach (var line in content.Lines)
         {
             float lineWidth = 0;
+            bool hasText = !string.IsNullOrEmpty(line.Text);
             if (line.LeadingIcon != null)
-                lineWidth += MeasureLineIconWidth(line, lineHeight) + IconTextGap;
-            if (!string.IsNullOrEmpty(line.Text))
+            {
+                lineWidth += MeasureLineIconWidth(line, lineHeight);
+                if (hasText)
+                    lineWidth += IconTextGap;
+            }
+            if (hasText)
                 lineWidth += UITheme.TooltipFont.MeasureString(line.Text).X;
             if (lineWidth > maxWidth)
                 maxWidth = lineWidth;
@@ -115,9 +120,10 @@ public class TooltipWidget : PanelWidget
         if (line.LeadingIcon == null)
             return 0;
         var src = line.LeadingIconSource ?? new Rectangle(0, 0, line.LeadingIcon.Width, line.LeadingIcon.Height);
-        if (src.Height <= 0)
+        if (src.Width <= 0 || src.Height <= 0)
             return lineHeight;
-        return lineHeight * (src.Width / (float)src.Height);
+        var iconWidth = lineHeight * (src.Width / (float)src.Height);
+        return iconWidth < 1f ? 1f : iconWidth;
     }
 
     private static Vector2 MeasureTableBlock(TooltipTableBlock table)
@@ -241,8 +247,9 @@ public class TooltipWidget : PanelWidget
 
             if (line.LeadingIcon != null)
             {
-                float iconWidth = MeasureLineIconWidth(line, lineHeight);
-                var iconRect = new Rectangle((int)pos.X, (int)pos.Y, (int)iconWidth, (int)lineHeight);
+                int iconWidth = (int)System.Math.Round(MeasureLineIconWidth(line, lineHeight));
+                int iconHeight = (int)System.Math.Round(lineHeight);
+                var iconRect = new Rectangle((int)pos.X, (int)pos.Y, iconWidth, iconHeight);
                 spriteBatch.Draw(line.LeadingIcon, iconRect, line.LeadingIconSource, Color.White);
                 textOffset = iconWidth + IconTextGap;
             }


### PR DESCRIPTION
## Summary
- Add `LeadingIcon` / `LeadingIconSource` to `TooltipLine` plus a new `TooltipContent.AddIconLine()` helper.
- `TooltipWidget` now measures and renders inline leading icons, sized to line height with a small text gap.

## Test plan
- [ ] Build passes (`dotnet build`)
- [ ] Tooltip with an icon line renders correctly in ChainwatchDescent