### PR TITLE
feat(ui): SliderWidget Step + Label + ValueFormatter + OnValueCommitted

### DIFF
--- a/Solo/UI/Widgets/SliderWidget.cs
+++ b/Solo/UI/Widgets/SliderWidget.cs
@@ -65,6 +65,10 @@ public class SliderWidget : Widget
 
     public event Action<int>? OnValueChanged;
 
+    /// <summary>
+    /// Fires once per commit (e.g., mouse-up after a drag) when the value differs from the baseline captured at first subscription.
+    /// The baseline advances on each successful commit and resets when all subscribers unsubscribe.
+    /// </summary>
     public event Action<int>? OnValueCommitted
     {
         add
@@ -76,7 +80,14 @@ public class SliderWidget : Widget
             }
             _onValueCommitted += value;
         }
-        remove => _onValueCommitted -= value;
+        remove
+        {
+            _onValueCommitted -= value;
+            if (_onValueCommitted == null)
+            {
+                _committedBaselineSet = false;
+            }
+        }
     }
 
     /// <summary>Test seam: simulates a mouse-release commit after a drag.</summary>

--- a/Solo/UI/Widgets/SliderWidget.cs
+++ b/Solo/UI/Widgets/SliderWidget.cs
@@ -13,24 +13,45 @@ public class SliderWidget : Widget
 
     private bool _isDragging;
     private int _value;
+    private int _step = 1;
+
+    // Baseline for OnValueCommitted: captured lazily when the first subscriber
+    // attaches, then advanced after every successful commit. This means
+    // subscribers are only notified about value changes that occur AFTER they
+    // subscribe — which matches both the production "mouse-up after drag" flow
+    // and ignores any object-initializer Value assignment performed before any
+    // listener was attached.
+    private int _committedValue;
+    private bool _committedBaselineSet;
+    private Action<int>? _onValueCommitted;
 
     public SliderWidget()
     {
         Size = new Vector2(200, ThumbHeight);
+        ValueFormatter = v => v.ToString();
     }
 
     public int MinValue { get; set; } = 0;
     public int MaxValue { get; set; } = 100;
+
+    public int Step
+    {
+        get => _step;
+        set => _step = value < 1 ? 1 : value;
+    }
+
+    public string? Label { get; set; }
+    public Func<int, string>? ValueFormatter { get; set; }
 
     public int Value
     {
         get => _value;
         set
         {
-            var clamped = Math.Clamp(value, MinValue, MaxValue);
-            if (_value != clamped)
+            var snapped = SnapToStep(Math.Clamp(value, MinValue, MaxValue));
+            if (_value != snapped)
             {
-                _value = clamped;
+                _value = snapped;
                 OnValueChanged?.Invoke(_value);
             }
         }
@@ -39,8 +60,45 @@ public class SliderWidget : Widget
     public Color TrackColor { get; set; } = UITheme.Scrollbar.Track;
     public Color ThumbColor { get; set; } = UITheme.Scrollbar.Thumb;
     public Color ThumbHoverColor { get; set; } = UITheme.Selection.SlotHover;
+    public Color LabelColor { get; set; } = UITheme.Text.Secondary;
+    public Color ValueColor { get; set; } = UITheme.Text.Primary;
 
     public event Action<int>? OnValueChanged;
+
+    public event Action<int>? OnValueCommitted
+    {
+        add
+        {
+            if (!_committedBaselineSet)
+            {
+                _committedValue = _value;
+                _committedBaselineSet = true;
+            }
+            _onValueCommitted += value;
+        }
+        remove => _onValueCommitted -= value;
+    }
+
+    /// <summary>Test seam: simulates a mouse-release commit after a drag.</summary>
+    public void CommitForTesting() => CommitIfChanged();
+
+    private int SnapToStep(int v)
+    {
+        if (_step <= 1) return v;
+        int offset = v - MinValue;
+        int snapped = MinValue + ((offset + _step / 2) / _step) * _step;
+        return Math.Clamp(snapped, MinValue, MaxValue);
+    }
+
+    private void CommitIfChanged()
+    {
+        if (!_committedBaselineSet) return;
+        if (_committedValue != _value)
+        {
+            _committedValue = _value;
+            _onValueCommitted?.Invoke(_value);
+        }
+    }
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
@@ -50,9 +108,9 @@ public class SliderWidget : Widget
     protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
     {
         var mousePoint = new Point(mouseState.X, mouseState.Y);
-        var thumbRect = GetThumbRect();
-        bool isOverThumb = thumbRect.Contains(mousePoint);
-        bool isOverTrack = Bounds.Contains(mousePoint);
+        var trackHit = GetTrackBounds();
+        bool isOverThumb = GetThumbRect().Contains(mousePoint);
+        bool isOverTrack = trackHit.Contains(mousePoint);
 
         if (mouseState.LeftButton == ButtonState.Pressed)
         {
@@ -68,38 +126,73 @@ public class SliderWidget : Widget
         }
         else
         {
-            _isDragging = false;
+            if (_isDragging)
+            {
+                _isDragging = false;
+                CommitIfChanged();
+            }
         }
 
         base.UpdateCore(gameTime, mouseState, previousMouseState);
     }
 
+    private Rectangle GetTrackBounds()
+    {
+        // Track region excludes label/value text columns.
+        var (trackLeft, trackWidth) = GetTrackHorizontalExtent();
+        return new Rectangle((int)trackLeft, (int)ScreenPosition.Y, (int)trackWidth, (int)Size.Y);
+    }
+
+    private (float left, float width) GetTrackHorizontalExtent()
+    {
+        float left = ScreenPosition.X;
+        float right = ScreenPosition.X + Size.X;
+
+        if (!string.IsNullOrEmpty(Label))
+        {
+            var labelSize = UITheme.Font.MeasureString(Label);
+            left += labelSize.X + 8;
+        }
+
+        if (ValueFormatter != null)
+        {
+            // Reserve space for the widest possible formatted value (use MaxValue as proxy).
+            var sample = ValueFormatter(MaxValue);
+            var sampleSize = UITheme.Font.MeasureString(sample);
+            right -= sampleSize.X + 8;
+        }
+
+        return (left, MathF.Max(0f, right - left));
+    }
+
     private void UpdateValueFromMouse(int mouseX)
     {
-        float trackStartX = ScreenPosition.X + ThumbWidth / 2f;
-        float trackEndX = ScreenPosition.X + Size.X - ThumbWidth / 2f;
-        float trackWidth = trackEndX - trackStartX;
+        var (trackLeft, trackWidth) = GetTrackHorizontalExtent();
+        float trackStartX = trackLeft + ThumbWidth / 2f;
+        float trackEndX = trackLeft + trackWidth - ThumbWidth / 2f;
+        float usableWidth = trackEndX - trackStartX;
 
-        if (trackWidth <= 0)
+        if (usableWidth <= 0)
             return;
 
         float relativeX = mouseX - trackStartX;
-        float ratio = Math.Clamp(relativeX / trackWidth, 0f, 1f);
+        float ratio = Math.Clamp(relativeX / usableWidth, 0f, 1f);
 
         int range = MaxValue - MinValue;
-        Value = MinValue + (int)MathF.Round(ratio * range);
+        Value = MinValue + (int)MathF.Round(ratio * range);   // setter snaps + clamps
     }
 
     private Rectangle GetThumbRect()
     {
-        float trackStartX = ScreenPosition.X + ThumbWidth / 2f;
-        float trackEndX = ScreenPosition.X + Size.X - ThumbWidth / 2f;
-        float trackWidth = trackEndX - trackStartX;
+        var (trackLeft, trackWidth) = GetTrackHorizontalExtent();
+        float trackStartX = trackLeft + ThumbWidth / 2f;
+        float trackEndX = trackLeft + trackWidth - ThumbWidth / 2f;
+        float usableWidth = trackEndX - trackStartX;
 
         int range = MaxValue - MinValue;
         float ratio = range > 0 ? (float)(_value - MinValue) / range : 0f;
 
-        float thumbCenterX = trackStartX + ratio * trackWidth;
+        float thumbCenterX = trackStartX + ratio * usableWidth;
         float thumbY = ScreenPosition.Y + (Size.Y - ThumbHeight) / 2f;
 
         return new Rectangle(
@@ -114,19 +207,33 @@ public class SliderWidget : Widget
     {
         var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
 
-        // Draw track
+        // Label (left)
+        if (!string.IsNullOrEmpty(Label))
+        {
+            var labelSize = UITheme.Font.MeasureString(Label);
+            float labelY = ScreenPosition.Y + (Size.Y - labelSize.Y) / 2f;
+            spriteBatch.DrawString(UITheme.Font, Label, new Vector2(ScreenPosition.X, labelY), LabelColor);
+        }
+
+        // Track
+        var (trackLeft, trackWidth) = GetTrackHorizontalExtent();
         float trackY = ScreenPosition.Y + (Size.Y - TrackHeight) / 2f;
-        var trackRect = new Rectangle(
-            (int)ScreenPosition.X,
-            (int)trackY,
-            (int)Size.X,
-            TrackHeight
-        );
+        var trackRect = new Rectangle((int)trackLeft, (int)trackY, (int)trackWidth, TrackHeight);
         spriteBatch.Draw(pixel, trackRect, TrackColor);
 
-        // Draw thumb
+        // Thumb
         var thumbRect = GetThumbRect();
         var thumbColor = _isDragging ? ThumbHoverColor : ThumbColor;
         spriteBatch.Draw(pixel, thumbRect, thumbColor);
+
+        // Value (right)
+        if (ValueFormatter != null)
+        {
+            var text = ValueFormatter(_value);
+            var textSize = UITheme.Font.MeasureString(text);
+            float textX = ScreenPosition.X + Size.X - textSize.X;
+            float textY = ScreenPosition.Y + (Size.Y - textSize.Y) / 2f;
+            spriteBatch.DrawString(UITheme.Font, text, new Vector2(textX, textY), ValueColor);
+        }
     }
 }

--- a/Solo/UI/Widgets/SliderWidget.cs
+++ b/Solo/UI/Widgets/SliderWidget.cs
@@ -14,6 +14,15 @@ public class SliderWidget : Widget
     private bool _isDragging;
     private int _value;
     private int _step = 1;
+    private int _maxValue = 100;
+    private string? _label;
+    private Func<int, string>? _valueFormatter;
+
+    // Cached widths for label / value-readout text. Reserved space depends only on
+    // Label/ValueFormatter/MaxValue, so we recompute lazily and invalidate via setters
+    // instead of calling MeasureString every frame.
+    private float? _cachedLabelWidth;
+    private float? _cachedValueWidth;
 
     // Baseline for OnValueCommitted: captured lazily when the first subscriber
     // attaches, then advanced after every successful commit. This means
@@ -32,16 +41,52 @@ public class SliderWidget : Widget
     }
 
     public int MinValue { get; set; } = 0;
-    public int MaxValue { get; set; } = 100;
+
+    public int MaxValue
+    {
+        get => _maxValue;
+        set
+        {
+            if (_maxValue == value) return;
+            _maxValue = value;
+            _cachedValueWidth = null;
+        }
+    }
 
     public int Step
     {
         get => _step;
-        set => _step = value < 1 ? 1 : value;
+        set
+        {
+            var normalizedStep = value < 1 ? 1 : value;
+            if (_step == normalizedStep) return;
+            _step = normalizedStep;
+            // Re-snap current value so an out-of-step Value set before Step doesn't linger.
+            Value = _value;
+        }
     }
 
-    public string? Label { get; set; }
-    public Func<int, string>? ValueFormatter { get; set; }
+    public string? Label
+    {
+        get => _label;
+        set
+        {
+            if (_label == value) return;
+            _label = value;
+            _cachedLabelWidth = null;
+        }
+    }
+
+    public Func<int, string>? ValueFormatter
+    {
+        get => _valueFormatter;
+        set
+        {
+            if (ReferenceEquals(_valueFormatter, value)) return;
+            _valueFormatter = value;
+            _cachedValueWidth = null;
+        }
+    }
 
     public int Value
     {
@@ -90,8 +135,12 @@ public class SliderWidget : Widget
         }
     }
 
-    /// <summary>Test seam: simulates a mouse-release commit after a drag.</summary>
-    public void CommitForTesting() => CommitIfChanged();
+    /// <summary>
+    /// Forces an <see cref="OnValueCommitted"/> emission if the current value differs from the
+    /// last-committed baseline. The drag flow calls this on mouse-release; consumers (and tests)
+    /// can call it to commit programmatically.
+    /// </summary>
+    public void Commit() => CommitIfChanged();
 
     private int SnapToStep(int v)
     {
@@ -159,18 +208,17 @@ public class SliderWidget : Widget
         float left = ScreenPosition.X;
         float right = ScreenPosition.X + Size.X;
 
-        if (!string.IsNullOrEmpty(Label))
+        if (!string.IsNullOrEmpty(_label))
         {
-            var labelSize = UITheme.Font.MeasureString(Label);
-            left += labelSize.X + 8;
+            _cachedLabelWidth ??= UITheme.Font.MeasureString(_label).X;
+            left += _cachedLabelWidth.Value + 8;
         }
 
-        if (ValueFormatter != null)
+        if (_valueFormatter != null)
         {
             // Reserve space for the widest possible formatted value (use MaxValue as proxy).
-            var sample = ValueFormatter(MaxValue);
-            var sampleSize = UITheme.Font.MeasureString(sample);
-            right -= sampleSize.X + 8;
+            _cachedValueWidth ??= UITheme.Font.MeasureString(_valueFormatter(_maxValue)).X;
+            right -= _cachedValueWidth.Value + 8;
         }
 
         return (left, MathF.Max(0f, right - left));
@@ -198,7 +246,9 @@ public class SliderWidget : Widget
         var (trackLeft, trackWidth) = GetTrackHorizontalExtent();
         float trackStartX = trackLeft + ThumbWidth / 2f;
         float trackEndX = trackLeft + trackWidth - ThumbWidth / 2f;
-        float usableWidth = trackEndX - trackStartX;
+        // Clamp to 0 so a degenerate track (trackWidth < ThumbWidth) doesn't invert the thumb
+        // position. Mirrors the early-out in UpdateValueFromMouse for the same condition.
+        float usableWidth = MathF.Max(0f, trackEndX - trackStartX);
 
         int range = MaxValue - MinValue;
         float ratio = range > 0 ? (float)(_value - MinValue) / range : 0f;


### PR DESCRIPTION
Extends `SliderWidget` with several quality-of-life features needed by ChainwatchDescent's new Display options sliders (Brightness, Max Active Lights).

## Changes
- **`Step`** - snap `Value` to a configurable increment (default 1). Useful for percentage/discrete sliders. Setter re-snaps the current `Value` if it was assigned before `Step`.
- **`Label`** - optional caption rendered to the **left** of the track (track width shrinks to reserve space).
- **`ValueFormatter`** - `Func<int, string>` to customize the value-readout text rendered to the right of the track (e.g., `v => $"{v}%" `). Reserved width for the formatted text is cached and only recomputed when `Label`/`ValueFormatter`/`MaxValue` change.
- **`OnValueCommitted`** - fires once when the user finishes interacting (mouse-up after drag), in contrast to `OnValueChanged` which fires continuously while dragging. Enables `live-preview during drag, persist on commit` patterns without spamming I/O.
- **`Commit()`** - public method that emits `OnValueCommitted` if the current value differs from the last-committed baseline. Used by the drag flow and available to consumers (and tests) that want to commit programmatically.

## Implementation notes
`OnValueCommitted` uses a custom event accessor that captures the committed-baseline lazily on first subscription (and resets on full unsubscribe), so initializer-time `Value = N` assignments don't count as a change. This avoids spurious commits at construction time.

## Testing
9 unit tests covering Step snapping, formatter output, label rendering, commit semantics (drag/no-op), and baseline-reset on unsubscribe. Tests live in the consumer repo (no Solo test project exists).

## Note on base branch
This branch was developed on top of `feat/tooltip-leading-icon` because the consumer code depends on `TooltipContent.AddIconLine` from that branch. The diff against `main` therefore includes those 2 tooltip commits - please merge `feat/tooltip-leading-icon` first, or rebase this branch after that lands.

## Related
- Consumer PR: mizrael/ChainwatchDescent#91 (Display options: Brightness + Max Lights sliders)
