### PR TITLE
fix(ui): intersect scissor with ancestor's clip in nested scrollables

### DIFF
--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -12,6 +12,12 @@ public class PanelWidget : Widget
     private const int ScrollbarWidth = 6;
     private const int ScrollSpeed = 30;
 
+    /// <summary>Shared scissor-test-enabled rasterizer state for scrollable panels.
+    /// <see cref="RasterizerState"/> is a <see cref="GraphicsResource"/> with a finalizer +
+    /// driver-side allocation; sharing one across panels avoids per-frame GC + driver
+    /// resource churn (matches the engine's pattern with BlendState/SamplerState).</summary>
+    private static readonly RasterizerState ScissorEnabledRasterizer = new() { ScissorTestEnable = true };
+
     private float _scrollOffset;
     private int _previousScrollWheelValue;
 
@@ -210,24 +216,23 @@ public class PanelWidget : Widget
         var originalScissor = spriteBatch.GraphicsDevice.ScissorRectangle;
         var originalRasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
 
-        // Set up scissor rectangle for clipping (scissor is in screen space, so scale it)
         var scale = UITheme.UIScale;
         var sampler = scale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
         var matrix = scale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
-        var rasterizerState = new RasterizerState { ScissorTestEnable = true };
-        spriteBatch.GraphicsDevice.ScissorRectangle = new Rectangle(
+        var ourScissor = new Rectangle(
             (int)(contentBounds.X * scale),
             (int)(contentBounds.Y * scale),
             (int)(contentBounds.Width * scale),
             (int)(contentBounds.Height * scale)
         );
+        spriteBatch.GraphicsDevice.ScissorRectangle = Rectangle.Intersect(ourScissor, originalScissor);
 
         spriteBatch.Begin(
             SpriteSortMode.Deferred,
             BlendState.AlphaBlend,
             sampler,
             null,
-            rasterizerState,
+            ScissorEnabledRasterizer,
             null,
             matrix
         );

--- a/Solo/UI/Widgets/SelectableListWidget.cs
+++ b/Solo/UI/Widgets/SelectableListWidget.cs
@@ -8,6 +8,10 @@ namespace Solo.UI.Widgets;
 
 public class SelectableListWidget : PanelWidget
 {
+    /// <summary>Shared scissor-test-enabled rasterizer for list rendering. See
+    /// <see cref="PanelWidget"/> for the rationale.</summary>
+    private static readonly RasterizerState ScissorEnabledRasterizer = new() { ScissorTestEnable = true };
+
     private int _hoveredIndex = -1;
 
     public SelectableListWidget()
@@ -138,15 +142,15 @@ public class SelectableListWidget : PanelWidget
         var scale = UITheme.UIScale;
         var sampler = scale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
         var matrix = scale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
-        var rasterizerState = new RasterizerState { ScissorTestEnable = true };
-        spriteBatch.GraphicsDevice.ScissorRectangle = new Rectangle(
+        var ourScissor = new Rectangle(
             (int)(contentBounds.X * scale),
             (int)(contentBounds.Y * scale),
             (int)(contentBounds.Width * scale),
             (int)(contentBounds.Height * scale)
         );
+        spriteBatch.GraphicsDevice.ScissorRectangle = Rectangle.Intersect(ourScissor, originalScissor);
 
-        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, sampler, null, rasterizerState, null, matrix);
+        spriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, sampler, null, ScissorEnabledRasterizer, null, matrix);
 
         float y = ScreenPosition.Y + BorderWidth - ScrollOffset;
 


### PR DESCRIPTION
## Summary

- `PanelWidget.RenderScrollableChildren` and `SelectableListWidget.Render` previously overwrote `GraphicsDevice.ScissorRectangle` instead of intersecting with what an ancestor had already set. A list rendered inside a scrollable panel would draw its items past the outer panel's visible area.
- Both methods now compute `Rectangle.Intersect(ourScissor, originalScissor)`. MonoGame stores only one scissor rect, so the intersection has to be explicit. Empty intersections (non-overlapping rects) safely cull everything.
- Also hoists `RasterizerState { ScissorTestEnable = true }` to a `private static readonly` field. It's a `GraphicsResource` with a finalizer + driver-side allocation; allocating one per Render call churned GC and pressured the driver's resource pool.

## Why

Surfaced while implementing a two-column scrollable Display options panel in Chainwatch Descent — long `SelectableListWidget` instances were rendering past the outer scroll viewport. The fix benefits any nested scrollable widget in Solo, not just that one consumer.

## Related

- mizrael/ChainwatchDescent#TBD (consumer that exposed the bug)

## Test plan

- [x] Solo builds clean
- [x] Chainwatch Descent builds + 352/352 tests pass against this branch
- [x] Manual: nested `SelectableListWidget` inside the new `TwoColumnScrollPanel` clips correctly to the outer scroll area