### PR TITLE
feat(ui): expose PanelWidget.ScrollbarWidth as public const

### DIFF
--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -9,7 +9,11 @@ public class PanelWidget : Widget
 {
     private const int CloseButtonSize = 20;
     private const int CloseButtonMargin = 6;
-    private const int ScrollbarWidth = 6;
+    /// <summary>Reserved width (in logical UI pixels) for the vertical scrollbar gutter
+    /// when <see cref="Scrollable"/> is true. Subclasses that lay out custom scrollable
+    /// content can read this constant to avoid duplicating the magic number — e.g. when
+    /// reserving column space inside the panel's <see cref="ContentBounds"/>.</summary>
+    public const int ScrollbarWidth = 6;
     private const int ScrollSpeed = 30;
 
     private float _scrollOffset;


### PR DESCRIPTION
## Summary

- Promotes `PanelWidget.ScrollbarWidth = 6` from `private const` to `public const` with a short doc comment.
- Subclasses laying out custom scrollable content (multi-column scroll panels, side-by-side splits) can now reserve the scrollbar gutter without duplicating the magic number.

## Why

Surfaced as a code-review item on Chainwatch Descent's two-column scrollable Display panel (mizrael/ChainwatchDescent#97 review). The downstream `TwoColumnScrollPanel` was hardcoding `const int scrollbarReserve = 6` with a comment ""matches PanelWidget.ScrollbarWidth"" — fragile coupling that wouldn't compile-fail if the engine ever changed the value.

Exposing it as a public const lets the consumer reference `PanelWidget.ScrollbarWidth` directly. Cheap promotion with no behavioral change.

## Test plan

- [x] Solo builds clean
- [ ] Follow-up: chainwatch `TwoColumnScrollPanel` will be migrated to use the new constant in a separate PR