### PR TITLE
feat(ui): scrollable PanelWidget + TabbedPanelWidget polish

### DIFF
--- a/Solo/UI/Widgets/PanelWidget.cs
+++ b/Solo/UI/Widgets/PanelWidget.cs
@@ -24,6 +24,7 @@ public class PanelWidget : Widget
 
     private float _scrollOffset;
     private int _previousScrollWheelValue;
+    private bool _scrollWheelInitialized;
 
     public PanelWidget()
     {
@@ -35,6 +36,19 @@ public class PanelWidget : Widget
     public bool ShowCloseButton { get; set; } = true;
     public bool Scrollable { get; set; }
     public int ContentPadding { get; set; } = 16;
+
+    /// <summary>
+    /// When true, child rendering is clipped (via GPU scissor test) to the panel's
+    /// <see cref="ContentBounds"/> regardless of whether the panel is
+    /// <see cref="Scrollable"/>. Use this on container panels that host children
+    /// whose intrinsic size may exceed the parent's content area, to guarantee
+    /// they cannot visually spill past the panel's border. <see cref="Scrollable"/>
+    /// already implies clipping; this flag is only needed for non-scrollable
+    /// panels that want the same hard clip without a scrollbar.
+    /// Children are also blocked from receiving input outside the clip region
+    /// (mirrors the existing scrollable behaviour).
+    /// </summary>
+    public bool ClipToContentBounds { get; set; }
 
     public float ScrollOffset
     {
@@ -55,7 +69,7 @@ public class PanelWidget : Widget
     }
 
     protected override Rectangle? ChildInteractionClipBounds =>
-        Scrollable ? ContentBounds : null;
+        (Scrollable || ClipToContentBounds) ? ContentBounds : null;
 
     protected Rectangle CloseButtonBounds
     {
@@ -110,8 +124,14 @@ public class PanelWidget : Widget
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
         float horizontalChrome = ContentPadding * 2 + BorderWidth * 2 + (Scrollable ? ScrollbarWidth : 0);
+        float topOffset = ShowCloseButton ? CloseButtonSize + CloseButtonMargin : ContentPadding;
+        // Vertical chrome includes the close-button strip (or top padding when no close
+        // button), the bottom inner padding, and both top/bottom borders. Children must
+        // measure against the actual visible content height so they don't compute
+        // intrinsic sizes that overflow the panel's bottom edge.
+        float verticalChrome = topOffset + ContentPadding + BorderWidth * 2;
         float childAvailableWidth = Math.Max(0, availableWidth - horizontalChrome);
-        float childAvailableHeight = Math.Max(0, availableHeight);
+        float childAvailableHeight = Math.Max(0, availableHeight - verticalChrome);
 
         float maxRight = 0;
         float maxBottom = 0;
@@ -132,7 +152,6 @@ public class PanelWidget : Widget
                 maxBottom = childBottom;
         }
 
-        float topOffset = ShowCloseButton ? CloseButtonSize + CloseButtonMargin : ContentPadding;
         float width = maxRight + horizontalChrome;
         float height = topOffset + maxBottom + ContentPadding + BorderWidth * 2;
 
@@ -179,8 +198,16 @@ public class PanelWidget : Widget
             }
         }
 
-        // Handle mouse wheel scrolling
-        if (Scrollable && Bounds.Contains(mouseState.X, mouseState.Y))
+        // Handle mouse wheel scrolling. Initialize the wheel value on the first frame
+        // so a pre-existing absolute scroll value from before the panel was opened
+        // doesn't translate into a huge spurious delta and snap the panel to the
+        // bottom on its first interaction.
+        if (!_scrollWheelInitialized)
+        {
+            _previousScrollWheelValue = mouseState.ScrollWheelValue;
+            _scrollWheelInitialized = true;
+        }
+        else if (Scrollable && Bounds.Contains(mouseState.X, mouseState.Y))
         {
             int scrollDelta = mouseState.ScrollWheelValue - _previousScrollWheelValue;
             if (scrollDelta != 0)
@@ -198,7 +225,7 @@ public class PanelWidget : Widget
 
         RenderCore(spriteBatch);
 
-        if (Scrollable)
+        if (Scrollable || ClipToContentBounds)
         {
             RenderScrollableChildren(spriteBatch);
         }

--- a/Solo/UI/Widgets/TabbedPanelWidget.cs
+++ b/Solo/UI/Widgets/TabbedPanelWidget.cs
@@ -12,18 +12,30 @@ namespace Solo.UI.Widgets;
 /// <see cref="Next"/>, and <see cref="Previous"/>; mouse clicks on the strip jump
 /// directly to a tab. Subclasses can intercept switches by overriding
 /// <see cref="OnTabActivating"/>.
+///
+/// When <see cref="Scrollable"/> is true the tab strip stays pinned to the top of the
+/// widget and the active tab content scrolls within the remaining vertical space, with
+/// a vertical scrollbar painted in the right gutter (mirroring <see cref="PanelWidget"/>).
 /// </summary>
 public class TabbedPanelWidget : Widget
 {
     private const int TabStripVerticalPadding = 6;
     private const int TabStripHorizontalPadding = 12;
+    private const int ScrollSpeed = 30;
+
+    /// <summary>Shared scissor-test-enabled rasterizer state for scrollable tabbed panels.
+    /// Mirrors the equivalent constant in <see cref="PanelWidget"/> so we don't re-create
+    /// driver-side state on every frame.</summary>
+    private static readonly RasterizerState ScissorEnabledRasterizer = new() { ScissorTestEnable = true };
 
     private readonly IReadOnlyList<TabPage> _tabs;
     private int _activeIndex;
+    private float _scrollOffset;
+    private int _previousScrollWheelValue;
+    private bool _scrollWheelInitialized;
 
     /// <summary>Raised after a successful tab switch with (previousIndex, newIndex).</summary>
     public event Action<int, int>? ActiveTabChanged;
-
     public TabbedPanelWidget(IReadOnlyList<TabPage> tabs)
     {
         if (tabs == null) throw new ArgumentNullException(nameof(tabs));
@@ -72,11 +84,50 @@ public class TabbedPanelWidget : Widget
             _tabs[previous].Content.Visible = false;
             _tabs[value].Content.Visible = true;
             _activeIndex = value;
+            // Reset scroll so the new tab starts at its top instead of inheriting
+            // the previous tab's scroll position.
+            _scrollOffset = 0;
             ActiveTabChanged?.Invoke(previous, value);
         }
     }
 
     public IReadOnlyList<TabPage> Tabs => _tabs;
+
+    /// <summary>
+    /// When true, the active tab content scrolls vertically inside the area below the
+    /// tab strip and a scrollbar is painted in the right gutter. Children should NOT
+    /// also be Scrollable when this is enabled — the tabbed container owns scrolling.
+    /// </summary>
+    public bool Scrollable { get; set; }
+
+    /// <summary>
+    /// Inner horizontal padding (in logical UI pixels) applied between the panel's
+    /// left/right edges and the active tab's content area. Useful to keep tab content
+    /// away from the scrollbar gutter and add visual breathing room. Defaults to 0.
+    /// Note: this is intentionally horizontal-only and asymmetric with
+    /// <see cref="PanelWidget.ContentPadding"/> (which applies uniformly on all
+    /// sides) because <see cref="TabbedPanelWidget"/> has a pinned tab strip at the
+    /// top and an optional scrollbar on the right that need independent control.
+    /// Vertical spacing is controlled separately by <see cref="ContentTopPadding"/>.
+    /// </summary>
+    public int ContentHorizontalPadding { get; set; }
+
+    /// <summary>
+    /// Inner vertical padding (in logical UI pixels) inserted between the bottom of
+    /// the tab strip and the top of the active tab's content. Defaults to 0.
+    /// </summary>
+    public int ContentTopPadding { get; set; }
+
+    /// <summary>
+    /// Current scroll offset (in logical UI pixels). Clamped to <c>[0, MaxScrollOffset]</c>.
+    /// Mouse wheel events update this automatically when <see cref="Scrollable"/> is true
+    /// and the cursor is over the panel.
+    /// </summary>
+    public float ScrollOffset
+    {
+        get => _scrollOffset;
+        set => _scrollOffset = Math.Max(0, Math.Min(value, MaxScrollOffset));
+    }
 
     /// <summary>Switches to the next tab. No wrap; clamped at the last index.</summary>
     public void Next() => ActiveIndex = Math.Min(_activeIndex + 1, _tabs.Count - 1);
@@ -88,16 +139,91 @@ public class TabbedPanelWidget : Widget
     /// cancel the switch. Default returns true.</summary>
     protected virtual bool OnTabActivating(int previousIndex, int nextIndex) => true;
 
-    private int TabStripHeight => UITheme.LineHeight + TabStripVerticalPadding * 2;
+    private int TabStripHeight
+    {
+        get
+        {
+            try
+            {
+                var font = UITheme.Font;
+                if (font == null)
+                    return TabStripVerticalPadding * 2;
+                return font.LineSpacing + TabStripVerticalPadding * 2;
+            }
+            catch (NullReferenceException)
+            {
+                // Headless test contexts may not have a Font configured. Real
+                // rendering paths always have a Font.
+                return TabStripVerticalPadding * 2;
+            }
+        }
+    }
+
+    /// <summary>Translation applied to children when scrolling so click positions and
+    /// rendered positions both move together. Hidden tabs are not visible but still
+    /// shifted (cheap and consistent).</summary>
+    protected override Vector2 ChildRenderOffset =>
+        Scrollable ? new Vector2(0, -_scrollOffset) : Vector2.Zero;
+
+    /// <summary>When scrolling, child interactions outside the visible content area
+    /// (e.g. scrolled-up portions or the tab strip area itself) are blocked so a
+    /// scrolled-out widget can't intercept clicks meant for the tab strip.</summary>
+    protected override Rectangle? ChildInteractionClipBounds =>
+        Scrollable ? ContentBounds : null;
+
+    /// <summary>The visible content area (in screen space) below the tab strip and
+    /// excluding the scrollbar gutter when <see cref="Scrollable"/> is true.</summary>
+    private Rectangle ContentBounds
+    {
+        get
+        {
+            var screenPos = ScreenPosition;
+            int gutter = Scrollable ? PanelWidget.ScrollbarWidth : 0;
+            int top = TabStripHeight + ContentTopPadding;
+            return new Rectangle(
+                (int)screenPos.X + ContentHorizontalPadding,
+                (int)screenPos.Y + top,
+                Math.Max(0, (int)Size.X - gutter - ContentHorizontalPadding * 2),
+                Math.Max(0, (int)Size.Y - top)
+            );
+        }
+    }
+
+    /// <summary>Natural height of the active tab's content. Used to compute the
+    /// scrollbar thumb size and clamp <see cref="ScrollOffset"/>.</summary>
+    private float ActiveContentHeight =>
+        _tabs.Count == 0 ? 0 : _tabs[_activeIndex].Content.DesiredSize.Y;
+
+    /// <summary>Maximum valid <see cref="ScrollOffset"/> for the current viewport.</summary>
+    private float MaxScrollOffset
+    {
+        get
+        {
+            if (!Scrollable)
+                return 0;
+            return Math.Max(0, ActiveContentHeight - ContentBounds.Height);
+        }
+    }
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
-        float contentAvailableHeight = Math.Max(0, availableHeight - TabStripHeight);
+        // When scrollable, give children unlimited height so they report their natural
+        // size; the tabbed panel itself fills the available rectangle and provides the
+        // scrollbar. When not scrollable, fall back to the original "biggest tab wins"
+        // behaviour: the panel grows to fit its tallest child.
+        float gutter = Scrollable ? PanelWidget.ScrollbarWidth : 0;
+        float horizontalChrome = gutter + ContentHorizontalPadding * 2;
+        float verticalChrome = TabStripHeight + ContentTopPadding;
+        float contentMeasureWidth = Math.Max(0, availableWidth - horizontalChrome);
+        float contentMeasureHeight = Scrollable
+            ? float.MaxValue
+            : Math.Max(0, availableHeight - verticalChrome);
+
         float maxW = 0;
         float maxH = 0;
         foreach (var tab in _tabs)
         {
-            tab.Content.Measure(availableWidth, contentAvailableHeight);
+            tab.Content.Measure(contentMeasureWidth, contentMeasureHeight);
             maxW = Math.Max(maxW, tab.Content.DesiredSize.X);
             maxH = Math.Max(maxH, tab.Content.DesiredSize.Y);
         }
@@ -105,9 +231,15 @@ public class TabbedPanelWidget : Widget
         // Ensure the requested width is at least wide enough to fit every tab title in
         // the strip; otherwise narrow content + long titles would clip/overlap labels.
         float titleStripWidth = MeasureTabStripWidth();
-        float requestedWidth = Math.Max(maxW, titleStripWidth);
+        float requestedWidth = Math.Max(maxW + horizontalChrome, titleStripWidth);
 
-        return new Vector2(requestedWidth, maxH + TabStripHeight);
+        // Scrollable: fill the parent area vertically (scrollbar handles overflow).
+        // Non-scrollable: grow to fit the tallest tab.
+        float requestedHeight = Scrollable && availableHeight > 0
+            ? availableHeight
+            : maxH + verticalChrome;
+
+        return new Vector2(requestedWidth, requestedHeight);
     }
 
     private float MeasureTabStripWidth()
@@ -134,14 +266,37 @@ public class TabbedPanelWidget : Widget
     {
         foreach (var tab in _tabs)
         {
-            tab.Content.Position = new Vector2(0, TabStripHeight);
+            tab.Content.Position = new Vector2(ContentHorizontalPadding, TabStripHeight + ContentTopPadding);
             tab.Content.Arrange(tab.Content.DesiredSize);
         }
+
+        // Re-clamp the scroll offset after layout in case the active tab shrank or the
+        // viewport grew, leaving us scrolled past the new max.
+        if (Scrollable)
+            _scrollOffset = Math.Max(0, Math.Min(_scrollOffset, MaxScrollOffset));
     }
 
     protected override void UpdateCore(GameTime gameTime, MouseState mouseState, MouseState previousMouseState)
     {
         base.UpdateCore(gameTime, mouseState, previousMouseState);
+
+        // Mouse-wheel scrolling: only consume wheel deltas while the cursor is over
+        // this widget so other scrollable siblings on screen aren't double-scrolled.
+        // Initialize the wheel value on the first frame so a pre-existing absolute
+        // scroll value from before the panel was opened doesn't translate into a
+        // huge spurious delta and snap the panel to the bottom on its first frame.
+        if (!_scrollWheelInitialized)
+        {
+            _previousScrollWheelValue = mouseState.ScrollWheelValue;
+            _scrollWheelInitialized = true;
+        }
+        else if (Scrollable && Bounds.Contains(mouseState.X, mouseState.Y))
+        {
+            int scrollDelta = mouseState.ScrollWheelValue - _previousScrollWheelValue;
+            if (scrollDelta != 0)
+                ScrollOffset -= scrollDelta / 120f * ScrollSpeed;
+        }
+        _previousScrollWheelValue = mouseState.ScrollWheelValue;
 
         bool clicked = mouseState.LeftButton == ButtonState.Pressed
             && previousMouseState.LeftButton == ButtonState.Released;
@@ -187,9 +342,96 @@ public class TabbedPanelWidget : Widget
             return;
         RenderTabStrip(spriteBatch);
         RenderCore(spriteBatch);
-        // Children render themselves; only the active tab's Content has Visible = true.
+
+        if (Scrollable)
+        {
+            RenderScrollableChildren(spriteBatch);
+        }
+        else
+        {
+            // Children render themselves; only the active tab's Content has Visible = true.
+            foreach (var child in Children)
+                child.Render(spriteBatch);
+        }
+    }
+
+    private void RenderScrollableChildren(SpriteBatch spriteBatch)
+    {
+        var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
+        var contentBounds = ContentBounds;
+
+        // End the current batch so we can swap rasterizer state to one with scissor
+        // testing enabled and clip child rendering to the content area.
+        spriteBatch.End();
+
+        var originalScissor = spriteBatch.GraphicsDevice.ScissorRectangle;
+        var originalRasterizerState = spriteBatch.GraphicsDevice.RasterizerState;
+
+        var scale = UITheme.UIScale;
+        var sampler = scale < 1f ? SamplerState.LinearClamp : SamplerState.PointClamp;
+        var matrix = scale < 1f ? UITheme.UIScaleMatrix : (Matrix?)null;
+        var ourScissor = new Rectangle(
+            (int)(contentBounds.X * scale),
+            (int)(contentBounds.Y * scale),
+            (int)(contentBounds.Width * scale),
+            (int)(contentBounds.Height * scale)
+        );
+        spriteBatch.GraphicsDevice.ScissorRectangle = Rectangle.Intersect(ourScissor, originalScissor);
+
+        spriteBatch.Begin(
+            SpriteSortMode.Deferred,
+            BlendState.AlphaBlend,
+            sampler,
+            null,
+            ScissorEnabledRasterizer,
+            null,
+            matrix
+        );
+
+        // Children render at their (positions + ChildRenderOffset which subtracts scroll).
         foreach (var child in Children)
             child.Render(spriteBatch);
+
+        spriteBatch.End();
+
+        // Restore original state for the scrollbar and any subsequent draws.
+        spriteBatch.GraphicsDevice.ScissorRectangle = originalScissor;
+
+        spriteBatch.Begin(
+            SpriteSortMode.Deferred,
+            BlendState.AlphaBlend,
+            sampler,
+            null,
+            originalRasterizerState,
+            null,
+            matrix
+        );
+
+        RenderScrollbar(spriteBatch, pixel, contentBounds);
+    }
+
+    private void RenderScrollbar(SpriteBatch spriteBatch, Texture2D pixel, Rectangle contentBounds)
+    {
+        if (MaxScrollOffset <= 0)
+            return;
+
+        int scrollbarX = (int)ScreenPosition.X + (int)Size.X - PanelWidget.ScrollbarWidth;
+        int scrollbarHeight = contentBounds.Height;
+
+        // Track
+        spriteBatch.Draw(pixel,
+            new Rectangle(scrollbarX, contentBounds.Y, PanelWidget.ScrollbarWidth, scrollbarHeight),
+            UITheme.Scrollbar.Track);
+
+        // Thumb
+        float thumbRatio = contentBounds.Height / (contentBounds.Height + MaxScrollOffset);
+        int thumbHeight = Math.Max(20, (int)(scrollbarHeight * thumbRatio));
+        float scrollRatio = MaxScrollOffset > 0 ? _scrollOffset / MaxScrollOffset : 0;
+        int thumbY = contentBounds.Y + (int)((scrollbarHeight - thumbHeight) * scrollRatio);
+
+        spriteBatch.Draw(pixel,
+            new Rectangle(scrollbarX, thumbY, PanelWidget.ScrollbarWidth, thumbHeight),
+            UITheme.Scrollbar.Thumb);
     }
 
     private void RenderTabStrip(SpriteBatch spriteBatch)

--- a/Solo/UI/Widgets/TabbedPanelWidget.cs
+++ b/Solo/UI/Widgets/TabbedPanelWidget.cs
@@ -143,19 +143,12 @@ public class TabbedPanelWidget : Widget
     {
         get
         {
-            try
-            {
-                var font = UITheme.Font;
-                if (font == null)
-                    return TabStripVerticalPadding * 2;
-                return font.LineSpacing + TabStripVerticalPadding * 2;
-            }
-            catch (NullReferenceException)
-            {
-                // Headless test contexts may not have a Font configured. Real
-                // rendering paths always have a Font.
+            // Headless test contexts may not have a Font configured. Real
+            // rendering paths always have a Font.
+            var font = UITheme.Font;
+            if (font == null)
                 return TabStripVerticalPadding * 2;
-            }
+            return font.LineSpacing + TabStripVerticalPadding * 2;
         }
     }
 
@@ -235,7 +228,11 @@ public class TabbedPanelWidget : Widget
 
         // Scrollable: fill the parent area vertically (scrollbar handles overflow).
         // Non-scrollable: grow to fit the tallest tab.
-        float requestedHeight = Scrollable && availableHeight > 0
+        // float.MaxValue is the codebase convention for "unconstrained" height
+        // (e.g. TooltipWidget); reflecting it back as desired height would yield
+        // a nonsensical size, so fall back to content-driven sizing in that case.
+        bool hasBoundedHeight = availableHeight > 0 && availableHeight < float.MaxValue;
+        float requestedHeight = (Scrollable && hasBoundedHeight)
             ? availableHeight
             : maxH + verticalChrome;
 
@@ -244,22 +241,15 @@ public class TabbedPanelWidget : Widget
 
     private float MeasureTabStripWidth()
     {
-        try
-        {
-            var font = UITheme.Font;
-            if (font == null)
-                return 0;
-            float maxTitle = 0;
-            foreach (var tab in _tabs)
-                maxTitle = Math.Max(maxTitle, font.MeasureString(tab.Title).X);
-            return (maxTitle + TabStripHorizontalPadding * 2) * _tabs.Count;
-        }
-        catch (NullReferenceException)
-        {
-            // Headless test contexts may not have a Font configured; fall back to
-            // letting content drive width. Real rendering paths always have a Font.
+        // Headless test contexts may not have a Font configured; fall back to
+        // letting content drive width. Real rendering paths always have a Font.
+        var font = UITheme.Font;
+        if (font == null)
             return 0;
-        }
+        float maxTitle = 0;
+        foreach (var tab in _tabs)
+            maxTitle = Math.Max(maxTitle, font.MeasureString(tab.Title).X);
+        return (maxTitle + TabStripHorizontalPadding * 2) * _tabs.Count;
     }
 
     protected override void ArrangeCore(Vector2 finalSize)
@@ -415,17 +405,21 @@ public class TabbedPanelWidget : Widget
         if (MaxScrollOffset <= 0)
             return;
 
-        int scrollbarX = (int)ScreenPosition.X + (int)Size.X - PanelWidget.ScrollbarWidth;
         int scrollbarHeight = contentBounds.Height;
+        if (scrollbarHeight <= 0)
+            return;
+
+        int scrollbarX = (int)ScreenPosition.X + (int)Size.X - PanelWidget.ScrollbarWidth;
 
         // Track
         spriteBatch.Draw(pixel,
             new Rectangle(scrollbarX, contentBounds.Y, PanelWidget.ScrollbarWidth, scrollbarHeight),
             UITheme.Scrollbar.Track);
 
-        // Thumb
+        // Thumb. Clamp to scrollbarHeight so the minimum-height enforcement (20px)
+        // doesn't push the thumb above the track when the visible area is tiny.
         float thumbRatio = contentBounds.Height / (contentBounds.Height + MaxScrollOffset);
-        int thumbHeight = Math.Max(20, (int)(scrollbarHeight * thumbRatio));
+        int thumbHeight = Math.Min(scrollbarHeight, Math.Max(20, (int)(scrollbarHeight * thumbRatio)));
         float scrollRatio = MaxScrollOffset > 0 ? _scrollOffset / MaxScrollOffset : 0;
         int thumbY = contentBounds.Y + (int)((scrollbarHeight - thumbHeight) * scrollRatio);
 


### PR DESCRIPTION
## Summary

- Adds `Scrollable` mode to `PanelWidget` (mouse-wheel + clipped viewport rendering) and surfaces matching scroll/clipping APIs on `TabbedPanelWidget` so the active tab content scrolls independently of the tab strip.
- Fixes two layout bugs: `MeasureCore` now subtracts vertical chrome (border + padding + scrollbar reservation) from available height *before* measuring children, and the mouse-wheel handler ignores the first-frame delta so the panel no longer jumps the first time the cursor enters it.
- Renames for clarity: `ClipChildren` → `ClipToContentBounds` (clarified that `Scrollable` already implies clipping); `TabbedPanelWidget.ContentPadding` → `ContentHorizontalPadding`, plus a new `ContentTopPadding` for breathing room below the tab strip.
- Resets `TabbedPanelWidget.ScrollOffset` to `0` whenever the active tab changes, and makes `TabStripHeight` headless-safe so unit tests can exercise Measure/Arrange paths.

## Consumer

These APIs are consumed by [mizrael/ChainwatchDescent](https://github.com/mizrael/ChainwatchDescent) for the new tabbed PlayerPanel (Inventory / Stats / Metrics / Abilities). Companion PR pending.

## Test plan
- [x] `dotnet build Solo/Solo.csproj` — clean (0 errors)
- [x] Consumer test suite passes: 433/433 in ChainwatchDescent (includes 7 new TabbedPanelWidget tests covering ScrollOffset clamping, tab-switch scroll reset, and content padding behavior)
- [x] Manual smoke: scrolled tabs in PlayerPanel; verified mouse-wheel no longer jumps on first hover; verified content does not extend below tab strip / outside panel borders.
