### PR TITLE
fix(ui): make row widgets responsive to arranged width

### DIFF
--- a/Solo.Tests/Solo.Tests.csproj
+++ b/Solo.Tests/Solo.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Solo\Solo.csproj" />
+  </ItemGroup>
+</Project>

--- a/Solo.Tests/UI/Widgets/MetricRowWidgetTests.cs
+++ b/Solo.Tests/UI/Widgets/MetricRowWidgetTests.cs
@@ -1,0 +1,25 @@
+using Solo.UI.Widgets;
+using Xunit;
+
+namespace Solo.Tests.UI.Widgets;
+
+public sealed class MetricRowWidgetTests
+{
+    [Fact]
+    public void CalculateValueX_WhenRowWidthExpands_AnchorsValueToNewRightEdge()
+    {
+        float narrowX = MetricRowWidget.CalculateValueX(rowX: 10, rowWidth: 300, valueWidth: 42);
+        float wideX = MetricRowWidget.CalculateValueX(rowX: 10, rowWidth: 620, valueWidth: 42);
+
+        Assert.Equal(268, narrowX);
+        Assert.Equal(588, wideX);
+    }
+
+    [Fact]
+    public void CalculateValueX_WhenValueIsWiderThanRow_DoesNotMoveLeftOfRow()
+    {
+        float valueX = MetricRowWidget.CalculateValueX(rowX: 25, rowWidth: 40, valueWidth: 120);
+
+        Assert.Equal(25, valueX);
+    }
+}

--- a/Solo.Tests/UI/Widgets/StatProgressRowWidgetTests.cs
+++ b/Solo.Tests/UI/Widgets/StatProgressRowWidgetTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Xna.Framework;
+using Solo.UI.Widgets;
+using Xunit;
+
+namespace Solo.Tests.UI.Widgets;
+
+public sealed class StatProgressRowWidgetTests
+{
+    [Fact]
+    public void CalculateProgressBarBounds_WhenLabelColumnWidthProvided_UsesColumnWidthForBarStart()
+    {
+        var bounds = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: Vector2.Zero,
+            rowSize: new Vector2(300, 20),
+            labelWidth: 60,
+            labelColumnWidth: 140);
+
+        Assert.Equal(152, bounds.X);
+        Assert.Equal(148, bounds.Width);
+    }
+
+    [Fact]
+    public void CalculateProgressBarBounds_WhenMeasuredLabelExceedsColumnWidth_UsesMeasuredWidthForBarStart()
+    {
+        var bounds = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: Vector2.Zero,
+            rowSize: new Vector2(300, 20),
+            labelWidth: 160,
+            labelColumnWidth: 140);
+
+        Assert.Equal(172, bounds.X);
+        Assert.Equal(128, bounds.Width);
+    }
+
+    [Fact]
+    public void CalculateProgressBarBounds_WhenLabelColumnWidthMissing_UsesMeasuredLabelWidthForBarStart()
+    {
+        var bounds = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: Vector2.Zero,
+            rowSize: new Vector2(300, 20),
+            labelWidth: 60);
+
+        Assert.Equal(72, bounds.X);
+        Assert.Equal(228, bounds.Width);
+    }
+
+    [Fact]
+    public void CalculateProgressBarBounds_WhenRowWidthExpands_TracksNewRightEdge()
+    {
+        var narrow = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: Vector2.Zero,
+            rowSize: new Vector2(300, 20),
+            labelWidth: 90);
+
+        var wide = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: Vector2.Zero,
+            rowSize: new Vector2(620, 20),
+            labelWidth: 90);
+
+        Assert.Equal(300, narrow.Right);
+        Assert.Equal(620, wide.Right);
+        Assert.True(wide.Width > narrow.Width);
+    }
+
+    [Fact]
+    public void CalculateProgressBarBounds_WhenLabelConsumesRow_DoesNotCreateNegativeWidth()
+    {
+        var bounds = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: new Vector2(5, 7),
+            rowSize: new Vector2(80, 20),
+            labelWidth: 120);
+
+        Assert.Equal(85, bounds.X);
+        Assert.Equal(0, bounds.Width);
+        Assert.Equal(8, bounds.Y);
+        Assert.Equal(18, bounds.Height);
+    }
+
+    [Theory]
+    [InlineData(20, 8, 18)]
+    [InlineData(22, 8, 20)]
+    public void CalculateProgressBarBounds_WhenRowHeightAllows_UsesOnePixelVerticalInset(float rowHeight, int expectedY, int expectedHeight)
+    {
+        var bounds = StatProgressRowWidget.CalculateProgressBarBounds(
+            rowPosition: new Vector2(5, 7),
+            rowSize: new Vector2(300, rowHeight),
+            labelWidth: 90);
+
+        Assert.Equal(expectedY, bounds.Y);
+        Assert.Equal(expectedHeight, bounds.Height);
+    }
+
+    [Fact]
+    public void CalculatePercentTextPosition_WhenTextFits_CentersTextInsideProgressBar()
+    {
+        var position = StatProgressRowWidget.CalculatePercentTextPosition(
+            barBounds: new Rectangle(110, 8, 190, 18),
+            percentSize: new Vector2(24, 12));
+
+        Assert.Equal(193, position.X);
+        Assert.Equal(11, position.Y);
+    }
+
+    [Theory]
+    [InlineData(100, 18, 99f, 18f, true)]
+    [InlineData(100, 18, 100.1f, 18f, false)]
+    [InlineData(100, 18, 99f, 18.1f, false)]
+    public void ShouldRenderPercentText_WhenTextDoesNotFitWidthOrHeight_ReturnsFalse(
+        int barWidth,
+        int barHeight,
+        float percentTextWidth,
+        float percentTextHeight,
+        bool expected)
+    {
+        bool shouldRender = StatProgressRowWidget.ShouldRenderPercentText(
+            new Rectangle(0, 0, barWidth, barHeight),
+            new Vector2(percentTextWidth, percentTextHeight));
+
+        Assert.Equal(expected, shouldRender);
+    }
+
+    [Theory]
+    [InlineData(-25, 0)]
+    [InlineData(0, 0)]
+    [InlineData(50, 100)]
+    [InlineData(100, 200)]
+    [InlineData(150, 200)]
+    public void CalculateFillWidth_ClampsProgressToBarWidth(float progress, int expectedFillWidth)
+    {
+        int fillWidth = StatProgressRowWidget.CalculateFillWidth(barWidth: 200, progress);
+
+        Assert.Equal(expectedFillWidth, fillWidth);
+    }
+
+    [Theory]
+    [InlineData(99, 99f, true)]
+    [InlineData(100, 100f, true)]
+    [InlineData(100, 100.1f, false)]
+    public void ShouldRenderPercentText_ReturnsFalseWhenTextIsWiderThanBar(int barWidth, float percentTextWidth, bool expected)
+    {
+        bool shouldRender = StatProgressRowWidget.ShouldRenderPercentText(barWidth, percentTextWidth);
+
+        Assert.Equal(expected, shouldRender);
+    }
+}

--- a/Solo.sln
+++ b/Solo.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteSheetEditor", "tools\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteSheetEditor.Tests", "tools\SpriteSheetEditor.Tests\SpriteSheetEditor.Tests.csproj", "{81240530-2BA3-EA35-C06E-5052679413C8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solo.Tests", "Solo.Tests\Solo.Tests.csproj", "{5C0AB5D6-64AD-45F3-B233-36DC82433E91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,18 @@ Global
 		{81240530-2BA3-EA35-C06E-5052679413C8}.Release|x64.Build.0 = Release|Any CPU
 		{81240530-2BA3-EA35-C06E-5052679413C8}.Release|x86.ActiveCfg = Release|Any CPU
 		{81240530-2BA3-EA35-C06E-5052679413C8}.Release|x86.Build.0 = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|x64.Build.0 = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Debug|x86.Build.0 = Debug|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|x64.ActiveCfg = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|x64.Build.0 = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|x86.ActiveCfg = Release|Any CPU
+		{5C0AB5D6-64AD-45F3-B233-36DC82433E91}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Solo/Solo.csproj
+++ b/Solo/Solo.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Solo.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/Solo/UI/Widgets/MetricRowWidget.cs
+++ b/Solo/UI/Widgets/MetricRowWidget.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -13,6 +14,9 @@ public class MetricRowWidget : Widget
     public string Value { get; set; } = string.Empty;
     public Color LabelColor { get; set; } = UITheme.Text.Secondary;
     public Color ValueColor { get; set; } = UITheme.Text.Primary;
+
+    internal static float CalculateValueX(float rowX, float rowWidth, float valueWidth) =>
+        rowX + Math.Max(0f, rowWidth - valueWidth);
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
@@ -30,7 +34,7 @@ public class MetricRowWidget : Widget
         if (!string.IsNullOrEmpty(Value))
         {
             var valueSize = UITheme.Font.MeasureString(Value);
-            float valueX = pos.X + Size.X - valueSize.X;
+            float valueX = CalculateValueX(pos.X, Size.X, valueSize.X);
             spriteBatch.DrawString(UITheme.Font, Value, new Vector2(valueX, pos.Y), ValueColor);
         }
     }

--- a/Solo/UI/Widgets/StatProgressRowWidget.cs
+++ b/Solo/UI/Widgets/StatProgressRowWidget.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
@@ -5,8 +6,8 @@ namespace Solo.UI.Widgets;
 
 public class StatProgressRowWidget : Widget
 {
-    private const int ProgressBarWidth = 100;
-    private const int ProgressBarHeight = 10;
+    private const int ProgressBarVerticalInset = 1;
+    private const int LabelBarGap = 12;
 
     public StatProgressRowWidget()
     {
@@ -17,6 +18,64 @@ public class StatProgressRowWidget : Widget
     public float Progress { get; set; }
     public Color BarColor { get; set; } = UITheme.StatusBar.ProgressFill;
     public Color LabelColor { get; set; } = UITheme.Text.Secondary;
+    public float? LabelColumnWidth { get; set; }
+
+    internal static float ResolveLabelColumnWidth(float measuredLabelWidth, float? labelColumnWidth)
+    {
+        return labelColumnWidth.HasValue
+            ? Math.Max(measuredLabelWidth, Math.Max(0, labelColumnWidth.Value))
+            : measuredLabelWidth;
+    }
+
+    internal static Rectangle CalculateProgressBarBounds(Vector2 rowPosition, Vector2 rowSize, float labelWidth, float? labelColumnWidth = null)
+    {
+        int rowLeft = (int)MathF.Round(rowPosition.X);
+        int rowTop = (int)MathF.Round(rowPosition.Y);
+        int rowWidth = Math.Max(0, (int)MathF.Round(rowSize.X));
+        int rowHeight = Math.Max(0, (int)MathF.Round(rowSize.Y));
+        int rowRight = rowLeft + rowWidth;
+        float resolvedLabelWidth = ResolveLabelColumnWidth(labelWidth, labelColumnWidth);
+        int labelRight = rowLeft + Math.Max(0, (int)MathF.Ceiling(resolvedLabelWidth));
+        int barLeft = Math.Min(rowRight, labelRight + LabelBarGap);
+        int barWidth = Math.Max(0, rowRight - barLeft);
+
+        int verticalInset = Math.Min(ProgressBarVerticalInset, rowHeight / 2);
+        int barHeight = Math.Max(0, rowHeight - verticalInset * 2);
+
+        return new Rectangle(barLeft, rowTop + verticalInset, barWidth, barHeight);
+    }
+
+    internal static int CalculateFillWidth(int barWidth, float progress)
+    {
+        if (barWidth <= 0)
+        {
+            return 0;
+        }
+
+        float ratio = Math.Clamp(progress / 100f, 0f, 1f);
+        return (int)(barWidth * ratio);
+    }
+
+    internal static bool ShouldRenderPercentText(int barWidth, float percentTextWidth)
+    {
+        return barWidth > 0 && percentTextWidth <= barWidth;
+    }
+
+    internal static bool ShouldRenderPercentText(Rectangle barBounds, Vector2 percentSize)
+    {
+        return barBounds.Width > 0
+            && barBounds.Height > 0
+            && percentSize.X <= barBounds.Width
+            && percentSize.Y <= barBounds.Height;
+    }
+
+    internal static Vector2 CalculatePercentTextPosition(Rectangle barBounds, Vector2 percentSize)
+    {
+        float x = barBounds.X + (barBounds.Width - percentSize.X) / 2f;
+        float y = barBounds.Y + (barBounds.Height - percentSize.Y) / 2f;
+
+        return new Vector2(x, y);
+    }
 
     protected override Vector2 MeasureCore(float availableWidth, float availableHeight)
     {
@@ -28,38 +87,39 @@ public class StatProgressRowWidget : Widget
         var pixel = UIResources.GetPixelTexture(spriteBatch.GraphicsDevice);
         var pos = ScreenPosition;
 
-        // Draw stat name and value
         string label = $"{StatName}: {StatValue:F0}";
+        var labelSize = UITheme.Font.MeasureString(label);
         spriteBatch.DrawString(UITheme.Font, label, pos, LabelColor);
 
-        // Draw progress bar
-        int barX = (int)(pos.X + Size.X - ProgressBarWidth);
-        int barY = (int)pos.Y + 4;
-
-        // Background
-        spriteBatch.Draw(pixel, new Rectangle(barX, barY, ProgressBarWidth, ProgressBarHeight), UITheme.StatusBar.ProgressBackground);
-
-        // Fill
-        int fillWidth = (int)(ProgressBarWidth * (Progress / 100f));
-        if (fillWidth > 0)
+        var barBounds = CalculateProgressBarBounds(pos, Size, labelSize.X, LabelColumnWidth);
+        if (barBounds.Width <= 0 || barBounds.Height <= 0)
         {
-            var fillColor = BarColor;
-            spriteBatch.Draw(pixel, new Rectangle(barX, barY, fillWidth, ProgressBarHeight), fillColor);
+            return;
         }
 
-        // Border
-        var borderColor = UITheme.Panel.BorderColor;
-        spriteBatch.Draw(pixel, new Rectangle(barX, barY, ProgressBarWidth, 1), borderColor);
-        spriteBatch.Draw(pixel, new Rectangle(barX, barY + ProgressBarHeight - 1, ProgressBarWidth, 1), borderColor);
-        spriteBatch.Draw(pixel, new Rectangle(barX, barY, 1, ProgressBarHeight), borderColor);
-        spriteBatch.Draw(pixel, new Rectangle(barX + ProgressBarWidth - 1, barY, 1, ProgressBarHeight), borderColor);
+        spriteBatch.Draw(pixel, barBounds, UITheme.StatusBar.ProgressBackground);
 
-        // Progress percentage
+        int fillWidth = CalculateFillWidth(barBounds.Width, Progress);
+        if (fillWidth > 0)
+        {
+            spriteBatch.Draw(pixel, new Rectangle(barBounds.X, barBounds.Y, fillWidth, barBounds.Height), BarColor);
+        }
+
+        var borderColor = UITheme.Panel.BorderColor;
+        spriteBatch.Draw(pixel, new Rectangle(barBounds.X, barBounds.Y, barBounds.Width, 1), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barBounds.X, barBounds.Bottom - 1, barBounds.Width, 1), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barBounds.X, barBounds.Y, 1, barBounds.Height), borderColor);
+        spriteBatch.Draw(pixel, new Rectangle(barBounds.Right - 1, barBounds.Y, 1, barBounds.Height), borderColor);
+
         string percentText = $"{Progress:F0}%";
         var percentSize = UITheme.Font.MeasureString(percentText);
-        float percentX = barX + (ProgressBarWidth - percentSize.X) / 2;
-        // Draw with shadow for readability
-        spriteBatch.DrawString(UITheme.Font, percentText, new Vector2(percentX + 1, pos.Y + 1), UITheme.Text.Shadow * 0.5f);
-        spriteBatch.DrawString(UITheme.Font, percentText, new Vector2(percentX, pos.Y), UITheme.Text.Primary);
+        if (!ShouldRenderPercentText(barBounds, percentSize))
+        {
+            return;
+        }
+
+        var percentPosition = CalculatePercentTextPosition(barBounds, percentSize);
+        spriteBatch.DrawString(UITheme.Font, percentText, percentPosition + Vector2.One, UITheme.Text.Shadow * 0.5f);
+        spriteBatch.DrawString(UITheme.Font, percentText, percentPosition, UITheme.Text.Primary);
     }
 }

--- a/Solo/UI/Widgets/StatProgressRowWidget.cs
+++ b/Solo/UI/Widgets/StatProgressRowWidget.cs
@@ -29,10 +29,11 @@ public class StatProgressRowWidget : Widget
 
     internal static Rectangle CalculateProgressBarBounds(Vector2 rowPosition, Vector2 rowSize, float labelWidth, float? labelColumnWidth = null)
     {
-        int rowLeft = (int)MathF.Round(rowPosition.X);
-        int rowTop = (int)MathF.Round(rowPosition.Y);
-        int rowWidth = Math.Max(0, (int)MathF.Round(rowSize.X));
-        int rowHeight = Math.Max(0, (int)MathF.Round(rowSize.Y));
+        // Match Widget.Bounds pixel snapping (truncation) so the bar never extends past the widget's drawn bounds.
+        int rowLeft = (int)rowPosition.X;
+        int rowTop = (int)rowPosition.Y;
+        int rowWidth = Math.Max(0, (int)rowSize.X);
+        int rowHeight = Math.Max(0, (int)rowSize.Y);
         int rowRight = rowLeft + rowWidth;
         float resolvedLabelWidth = ResolveLabelColumnWidth(labelWidth, labelColumnWidth);
         int labelRight = rowLeft + Math.Max(0, (int)MathF.Ceiling(resolvedLabelWidth));

--- a/games/Solocaster/Components/PlayerUIController.cs
+++ b/games/Solocaster/Components/PlayerUIController.cs
@@ -4,17 +4,18 @@ using Solo.Components;
 using Solo.Services;
 using Solocaster.Scenes;
 using Solocaster.Services;
+using SolocasterInputService = Solocaster.Services.InputService;
 
 namespace Solocaster.Components;
 
 public class PlayerUIController : Component
 {
-    private readonly InputService _inputService;
+    private readonly SolocasterInputService _inputService;
 
     public GameObject? MiniMapEntity { get; set; }
     public GameObject? DebugUIEntity { get; set; }
 
-    public PlayerUIController(GameObject owner, InputService inputService) : base(owner)
+    public PlayerUIController(GameObject owner, SolocasterInputService inputService) : base(owner)
     {
         _inputService = inputService;
     }

--- a/games/Solocaster/Scenes/CharacterPanelScene.cs
+++ b/games/Solocaster/Scenes/CharacterPanelScene.cs
@@ -4,6 +4,7 @@ using Solo.Services;
 using Solo.Services.Rendering;
 using Solocaster.Components;
 using Solocaster.Services;
+using SolocasterInputService = Solocaster.Services.InputService;
 using Solocaster.UI;
 
 namespace Solocaster.Scenes;
@@ -14,7 +15,7 @@ public class CharacterPanelScene : Scene
     private readonly StatsComponent _stats;
     private readonly RenderTarget2D _sceneCapture;
 
-    private InputService _inputService;
+    private SolocasterInputService _inputService;
     private UIService _uiService;
     private RenderPipeline _pipeline;
 
@@ -27,7 +28,7 @@ public class CharacterPanelScene : Scene
 
     protected override void InitializeCore()
     {
-        _inputService = new InputService();
+        _inputService = new SolocasterInputService();
         Services.Add(_inputService);
 
         _uiService = new UIService();

--- a/games/Solocaster/Scenes/MetricsPanelScene.cs
+++ b/games/Solocaster/Scenes/MetricsPanelScene.cs
@@ -4,6 +4,7 @@ using Solo.Services;
 using Solo.Services.Rendering;
 using Solocaster.Components;
 using Solocaster.Services;
+using SolocasterInputService = Solocaster.Services.InputService;
 using Solocaster.UI;
 
 namespace Solocaster.Scenes;
@@ -13,7 +14,7 @@ public class MetricsPanelScene : Scene
     private readonly StatsComponent _stats;
     private readonly RenderTarget2D _sceneCapture;
 
-    private InputService _inputService;
+    private SolocasterInputService _inputService;
     private UIService _uiService;
     private RenderPipeline _pipeline;
 
@@ -25,7 +26,7 @@ public class MetricsPanelScene : Scene
     
     protected override void InitializeCore()
     {
-        _inputService = new InputService();
+        _inputService = new SolocasterInputService();
         Services.Add(_inputService);
 
         _uiService = new UIService();

--- a/games/Solocaster/Scenes/PlayScene.cs
+++ b/games/Solocaster/Scenes/PlayScene.cs
@@ -10,6 +10,7 @@ using Solocaster.Inventory;
 using Solocaster.Monsters;
 using Solocaster.Persistence;
 using Solocaster.Services;
+using SolocasterInputService = Solocaster.Services.InputService;
 using Solocaster.State;
 using Solocaster.UI;
 
@@ -19,7 +20,7 @@ public class PlayScene : Scene
 {
     private const int FrameBufferScale = 2;
 
-    private InputService _inputService;
+    private SolocasterInputService _inputService;
     private UIService _uiService;
     private RenderTarget2D _sceneCapture;
     private RenderTarget2D _postProcess;
@@ -43,7 +44,7 @@ public class PlayScene : Scene
 
     protected override void InitializeCore()
     {
-        _inputService = new InputService();
+        _inputService = new SolocasterInputService();
         Services.Add(_inputService);
 
         _uiService = new UIService();


### PR DESCRIPTION
## Summary

Make `MetricRowWidget` and `StatProgressRowWidget` lay themselves out from their **arranged Size** rather than from constructor-time fixed widths. This unblocks consumers (specifically Chainwatch's `TabbedPlayerPanel`) where the final content width is only known after `Arrange` and changes when the tab body resizes.

## Why

Chainwatch's Metrics tab regressed after migrating `PlayerPanel` to `TabbedPlayerPanel` ([ChainwatchDescent#102](https://github.com/mizrael/ChainwatchDescent/issues/102)): rows kept their constructor width and never tracked the final tab body width. The fix needs to live in the engine because the row widgets are reusable building blocks, not Chainwatch-specific code.

## Changes

### `MetricRowWidget`

- Extract `CalculateValueX(rowX, rowWidth, valueWidth)` helper to right-align the value text against the row's right edge.
- Guard against overflow when the value width exceeds the row width.

### `StatProgressRowWidget`

- Replace fixed-width bar layout with helpers:
  - `CalculateProgressBarBounds` — bar tracks the row's right edge and clips when the label consumes the row.
  - `CalculateFillWidth` — clamps progress to `[0, 100]` % of bar width.
  - `CalculatePercentTextPosition` / `ShouldRenderPercentText` — vertically center the percent label inside the (now taller) bar and only draw when it fits.
  - `ResolveLabelColumnWidth` — optional shared label column, treated as a **minimum** so longer real labels never overlap their bar.

### Test infrastructure

- New `Solo.Tests` xUnit project (`net10.0`).
- 21 unit tests covering the new helpers: alignment, bar bounds, fill clamping, percent text fit, shared-column override / minimum semantics.
- `<InternalsVisibleTo Include="Solo.Tests" />` in `Solo.csproj`.

### Pre-existing Solocaster build fix

- Disambiguate `InputService` (collision between `Solo.Services` and `Solocaster.Services`) via `using SolocasterInputService = Solocaster.Services.InputService;` in 4 files. This was already broken on `main` and blocked the full `Solo.sln` build.

## Verification

- `dotnet test Solo.Tests/Solo.Tests.csproj` → 21/21 pass
- `dotnet build Solo.sln -p:EnableWindowsTargeting=true` → succeeds
- Cross-repo: ChainwatchDescent consumes the new widgets via its `MetricsPanel` rewrite (companion PR on ChainwatchDescent).

## Related

- Consumed by: ChainwatchDescent fix for [issue #102](https://github.com/mizrael/ChainwatchDescent/issues/102)